### PR TITLE
fix: remove vue package override

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "vite-plugin-vue-devtools": "^7.7.2",
     "vue-tsc": "^2.2.4"
   },
-  "overrides": {
-    "vue": "3.5.13"
-  },
   "engines": {
     "node": ">=20.9.0 <21"
   }


### PR DESCRIPTION
The override is no longer needed, as the component library now defines vue as peer instead of a dependency. 