### PR TITLE
feat: add custom field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@
 
 > - [ Overview](#overview)
 > - [ Features](#features)
-> - [ Getting Started](#getting-started)
->   - [ Installation](#local-installation)
->   - [ Replace hardcoded urls](#replace-hardcoded-urls)
->   - [ Develop locally](#develop-locally)
->   - [ Tests](#tests)
+> - [ Fraud Protection Advanced](https://github.com/shopware/braintree-app/wiki/2.-Fraud-Protection-Advanced)
+> - [ Getting Started](https://github.com/shopware/braintree-app/wiki/1.-Getting-started)
 > - [ Contributing](#contributing)
 > - [ License](#license)
 
@@ -46,7 +43,7 @@ This repository encompasses both the robust backend infrastructure and the corre
 
 :white_check_mark: Easy integration & maintenance
 
-:white_check_mark: Maximum security thanks to automatic 3-D Secure
+:white_check_mark: Maximum security thanks to automatic 3-D Secure and [Fraud Protection Advanced](https://github.com/shopware/braintree-app/wiki/2.-Fraud-Protection-Advanced)
 
 ---
 
@@ -54,74 +51,7 @@ This repository encompasses both the robust backend infrastructure and the corre
 
 If you are a merchant and want to install the app to your shop, you can find it [here](https://store.shopware.com/en/swag930601467972f/braintree-by-paypal.html)
 
-###  Local Installation
-
-1. First setup [devenv](https://developer.shopware.com/docs/guides/installation/devenv.html)
-2. Clone the repository
-   ```sh
-   git clone https://github.com/shopware/braintree-app
-   ```
-3. Install dependencies
-   ```sh
-   composer install
-   npm install
-   ```
-4. Start devenv
-   ```sh
-   devenv up
-   ```
-5. Setup database, manifest and hardcoded urls
-   ```sh
-   composer setup
-   ```
-6. Install and activate the app
-7. Rebuild shopware's storefront js
-
-### Replace hardcoded urls
-
-#### Via command
-
-Run `composer setup:manifest` to generate a manifest setup with the current `APP_URL`
-Run `composer setup:url` to replace hardcoded urls with your `APP_URL`, e.g. `http://localhost:8080`.
-
-#### Manually
-
-There are several hardcoded urls that need to be replaced when developing locally:
-- ~~`manifest.xml`~~ (Replaced by manifest templating with `composer setup:manifest`)
-- ~~`assets/src/service/api.ts`~~ (Replaced by origin url)
-- `Resources/app/storefront/src/checkout/swag-braintree.hosted-fields.js`
-  
-Replace `https://braintree.shopware.com` with your `APP_URL`, e.g. `http://localhost:8080`
-
-### Develop locally
-
-#### Administation
-- Build dev: `npm run dev`
-- Build prod: `npm run build`
-- Watch dev: `npm run watch`
-- ESLint: `composer eslint` or `composer eslint-fix`
-
-#### App Server
-- ECS: `composer ecs-fix`
-- PHPStan: `composer phpstan`
-- PHPUnit: `composer phpunit`
-- Infection: `composer infection`
-
-###  Tests
-
-To execute tests, run:
-
-```sh
-composer phpunit
-```
-
-This repository uses [mutation testing](https://infection.github.io/guide/) to determine effectiveness of unit tests.
-
-To test for mutations, run:
-
-```sh
-composer infection
-```
+For a local setup guide, take a look at [the wiki page](https://github.com/shopware/braintree-app/wiki/1.-Getting-started).
 
 ---
 

--- a/Resources/app/storefront/src/checkout/swag-braintree.hosted-fields.js
+++ b/Resources/app/storefront/src/checkout/swag-braintree.hosted-fields.js
@@ -44,6 +44,8 @@ export default class SwagBraintreeHostedFields extends Plugin {
         postalCodeFieldSelector: '#sw-braintree-payment-method__postalCode',
 
         cartAmount: 0,
+
+        customFields: {},
     }
 
     async init() {
@@ -243,12 +245,22 @@ export default class SwagBraintreeHostedFields extends Plugin {
     async validateWith3DSecure(braintree3DS, payload) {
         braintree3DS.on('lookup-complete', (_, next) => void next());
 
+        const event = new CustomEvent('braintreeVerifyCardCustomFields', {
+            detail: {
+                options: this.options,
+                customFields: this.options.customFields,
+            },
+        });
+
+        this.el.dispatchEvent(event);
+
         return braintree3DS.verifyCard({
             amount: this.options.cartAmount.toString(),
             nonce: payload.nonce,
             bin: payload.details.bin,
             collectDeviceData: true,
-        })
+            customFields: event.detail.customFields || undefined,
+        });
     }
 
     /**

--- a/Resources/views/storefront/braintree/component/checkout/braintree-hosted-fields.html.twig
+++ b/Resources/views/storefront/braintree/component/checkout/braintree-hosted-fields.html.twig
@@ -13,8 +13,10 @@
     currencyId: page.order.currencyId ?? context.currency.id,
     salesChannelId: context.salesChannel.id,
     noMerchantAccountId: 'braintree.noMerchantAccountId'|trans,
+    customFields: page.extensions.swag_braintree_app_custom_fields.all ?? null,
 } %}
 
+{% block component_braintree_hosted_fields %}
 <div data-swag-braintree-hosted-fields data-swag-braintree-hosted-fields-options="{{ pluginOptions|json_encode }}" class="swag-braintree-hosted-fields">
     <div id="sw-braintree-payment-method__number" class="form-control"></div>
 
@@ -27,3 +29,4 @@
 
     <div id="sw-braintree-payment-method__postalCode" class="form-control"></div>
 </div>
+{% endblock %}

--- a/manifest.xml
+++ b/manifest.xml
@@ -66,6 +66,25 @@
                 </text>
             </fields>
         </custom-field-set>
+        <custom-field-set>
+            <name>swag_braintree_app_order</name>
+            <label>Braintree by PayPal</label>
+            <label lang="de-DE">Braintree von PayPal</label>
+            <related-entities>
+                <order/>
+            </related-entities>
+            <fields>
+                <text name="swag_braintree_app_custom_fields">
+                    <position>1</position>
+                    <placeholder>JSON object, e.g. {"someField":"true"}</placeholder>
+                    <placeholder lang="de-DE">JSON Objekt, z.B. {"someField":"true"}</placeholder>
+                    <help-text>See https://developer.paypal.com/braintree/articles/control-panel/custom-fields for more information</help-text>
+                    <label>JSON object containing Braintree Custom Fields</label>
+                    <label lang="de-DE">JSON Objekt mit Braintree Custom Fields</label>
+                    <allow-cart-expose>true</allow-cart-expose>
+                </text>
+            </fields>
+        </custom-field-set>
     </custom-fields>
 
     <permissions>

--- a/src/Braintree/Payment/BraintreePaymentService.php
+++ b/src/Braintree/Payment/BraintreePaymentService.php
@@ -65,6 +65,7 @@ class BraintreePaymentService
             'shippingTaxAmount' => $this->orderInformationService->extractShippingTaxAmount($payment),
             'taxAmount' => $this->orderInformationService->extractTaxAmount($payment),
             'taxExempt' => $payment->order->getTaxStatus() === 'tax-free',
+            'customFields' => $this->orderInformationService->extractCustomFields($payment),
         ]);
 
         if (!$response->success) {

--- a/src/Braintree/Payment/OrderInformationService.php
+++ b/src/Braintree/Payment/OrderInformationService.php
@@ -12,6 +12,7 @@ class OrderInformationService
     public const LINE_ITEM_TYPE_DEBIT = 'debit';
     public const LINE_ITEM_TYPE_CREDIT = 'credit';
     public const LINE_ITEM_COMMODITY_CODE_CUSTOM_FIELD = 'swag_braintree_app_commodity_code';
+    public const CUSTOM_FIELDS = 'swag_braintree_app_custom_fields';
 
     public function __construct(
         private readonly TaxService $taxService,
@@ -130,6 +131,36 @@ class OrderInformationService
     public function extractSalesChannelId(PaymentPayAction $payment): string
     {
         return $payment->order->getSalesChannelId();
+    }
+
+    /**
+     * @return array<string, string|int>
+     */
+    public function extractCustomFields(PaymentPayAction $payment): array
+    {
+        $json = $payment->order->getCustomFields()[self::CUSTOM_FIELDS] ?? '{}';
+
+        if (!\is_string($json)) {
+            return [];
+        }
+
+        $customFields = \json_decode($json, true);
+
+        if (!\is_array($customFields)) {
+            return [];
+        }
+
+        $processedFields = [];
+        foreach ($customFields as $key => $value) {
+            if (!\is_string($key) || !\is_string($value) && !\is_numeric($value)) {
+                continue;
+            }
+
+            $key = $this->substr($key, 255);
+            $processedFields[$key] = $value;
+        }
+
+        return $processedFields;
     }
 
     /**

--- a/templates/manifest.xml.twig
+++ b/templates/manifest.xml.twig
@@ -69,6 +69,25 @@
                 </text>
             </fields>
         </custom-field-set>
+        <custom-field-set>
+            <name>swag_braintree_app_order</name>
+            <label>Braintree by PayPal</label>
+            <label lang="de-DE">Braintree von PayPal</label>
+            <related-entities>
+                <order/>
+            </related-entities>
+            <fields>
+                <text name="swag_braintree_app_custom_fields">
+                    <position>1</position>
+                    <placeholder>JSON object, e.g. {"someField":"true"}</placeholder>
+                    <placeholder lang="de-DE">JSON Objekt, z.B. {"someField":"true"}</placeholder>
+                    <help-text>See https://developer.paypal.com/braintree/articles/control-panel/custom-fields for more information</help-text>
+                    <label>JSON object containing Braintree Custom Fields</label>
+                    <label lang="de-DE">JSON Objekt mit Braintree Custom Fields</label>
+                    <allow-cart-expose>true</allow-cart-expose>
+                </text>
+            </fields>
+        </custom-field-set>
     </custom-fields>
 
     <permissions>

--- a/tests/unit/Braintree/Payment/OrderInformationServiceTest.php
+++ b/tests/unit/Braintree/Payment/OrderInformationServiceTest.php
@@ -3,6 +3,7 @@
 namespace Swag\Braintree\Tests\Unit\Braintree\Payment;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\App\SDK\Context\ActionSource;
 use Shopware\App\SDK\Context\Cart\LineItem;
@@ -280,5 +281,63 @@ class OrderInformationServiceTest extends TestCase
     {
         $shippingTaxAmount = $this->orderInformationService->extractShippingTaxAmount($this->paymentPayAction);
         static::assertSame(1.46, $shippingTaxAmount);
+    }
+
+    public function testExtractCustomFieldsWithoutFields(): void
+    {
+        $paymentPayAction = new PaymentPayAction(
+            $this->shop,
+            $this->paymentPayAction->source,
+            new Order(\array_merge(
+                $this->paymentPayAction->order->toArray(),
+                ['customFields' => []],
+            )),
+            $this->paymentPayAction->orderTransaction,
+        );
+
+        $result = $this->orderInformationService->extractCustomFields($paymentPayAction);
+
+        static::assertEquals([], $result);
+    }
+
+    /**
+     * @param array<mixed> $expected
+     */
+    #[DataProvider('providerExtractCustomFields')]
+    public function testExtractCustomFields(mixed $fields, array $expected): void
+    {
+        $paymentPayAction = new PaymentPayAction(
+            $this->shop,
+            $this->paymentPayAction->source,
+            new Order(\array_merge(
+                $this->paymentPayAction->order->toArray(),
+                ['customFields' => [OrderInformationService::CUSTOM_FIELDS => $fields]],
+            )),
+            $this->paymentPayAction->orderTransaction,
+        );
+
+        $result = $this->orderInformationService->extractCustomFields($paymentPayAction);
+
+        static::assertEquals($expected, $result);
+    }
+
+    public static function providerExtractCustomFields(): \Generator
+    {
+        yield 'non-json value, int' => [4, []];
+        yield 'non-json value, string' => ['some weird string', []];
+        yield 'non-json value, null' => [null, []];
+        yield 'json' => [\json_encode([
+            'int' => 4,
+            'float' => 4.4,
+            'object' => new \stdClass(),
+            'array' => ['some-value'],
+            \str_repeat('sdf', 89) => 'string-to-long',
+            'normal_field' => 'some-value',
+        ], \JSON_THROW_ON_ERROR), [
+            'int' => 4,
+            'float' => 4.4,
+            \str_repeat('sdf', 85) => 'string-to-long',
+            'normal_field' => 'some-value',
+        ]];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
Braintree has a [rule manager](https://developer.paypal.com/braintree/docs/guides/3d-secure/rules-manager/javascript/v3/#custom-fields), allowing for custom 3DS rules applied. Rules can be applied based on custom fields you pass to the `verifyCard(...)` or `transaction->sale(...)` call, where the latter seems more for data collection purposes.

### 2. What does this change do, exactly?
- Add the possibility to add custom fields via Twig, app hooks and JS
- Add the possibility to add custom fields via a custom field of the OrderEntity

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.