### PR TITLE
[6.6.x] feat: add custom field support

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,7 @@
+# 2.3.0
+
+* Fügt Unterstützung für Client-Side Custom Fields für die Fraud Protection Advanced Funktion hinzu
+
 # 2.2.0
 
 * Verbesserte Integration der (erweiterten) Betrugsprävention

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,7 @@
+# 2.3.0
+
+* Adds support for client-side Custom Fields for the Fraud Protection Advanced feature
+
 # 2.2.0
 
 + Improved support for (advanced) fraud protection

--- a/Resources/app/storefront/src/checkout/swag-braintree.hosted-fields.js
+++ b/Resources/app/storefront/src/checkout/swag-braintree.hosted-fields.js
@@ -45,6 +45,8 @@ export default class SwagBraintreeHostedFields extends Plugin {
         postalCodeFieldSelector: '#sw-braintree-payment-method__postalCode',
 
         cartAmount: 0,
+
+        customFields: {},
     }
 
     async init() {
@@ -244,12 +246,22 @@ export default class SwagBraintreeHostedFields extends Plugin {
     async validateWith3DSecure(braintree3DS, payload) {
         braintree3DS.on('lookup-complete', (_, next) => void next());
 
+        const event = new CustomEvent('braintreeVerifyCardCustomFields', {
+            detail: {
+                options: this.options,
+                customFields: this.options.customFields,
+            },
+        });
+
+        this.el.dispatchEvent(event);
+
         return braintree3DS.verifyCard({
             amount: this.options.cartAmount.toString(),
             nonce: payload.nonce,
             bin: payload.details.bin,
             collectDeviceData: true,
-        })
+            customFields: event.detail.customFields || undefined,
+        });
     }
 
     /**

--- a/Resources/views/storefront/braintree/component/checkout/braintree-hosted-fields.html.twig
+++ b/Resources/views/storefront/braintree/component/checkout/braintree-hosted-fields.html.twig
@@ -13,8 +13,10 @@
     currencyId: page.order.currencyId ?? context.currency.id,
     salesChannelId: context.salesChannel.id,
     noMerchantAccountId: 'braintree.noMerchantAccountId'|trans,
+    customFields: page.extensions.swag_braintree_app_custom_fields.all ?? null,
 } %}
 
+{% block component_braintree_hosted_fields %}
 <div data-swag-braintree-hosted-fields data-swag-braintree-hosted-fields-options="{{ pluginOptions|json_encode }}" class="swag-braintree-hosted-fields">
     <div id="sw-braintree-payment-method__number" class="form-control"></div>
 
@@ -27,3 +29,4 @@
 
     <div id="sw-braintree-payment-method__postalCode" class="form-control"></div>
 </div>
+{% endblock %}

--- a/manifest.xml
+++ b/manifest.xml
@@ -12,7 +12,7 @@
         <description lang="de-DE">Mit der App “PayPal Braintree” App von Shopware integrierst du ab sofort eine der beliebtesten Lösungen für Kreditkartenzahlungen ganz einfach in deinen Shop.</description>
         <author>shopware AG</author>
         <copyright>(c) by shopware AG</copyright>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
         <icon>Resources/plugin.webp</icon>
         <license>MIT</license>
         <compatibility>~6.6.0</compatibility>
@@ -62,6 +62,25 @@
                     <help-text>United Nations Standard Products and Services Code (UNSPSC). Search https://www.unspsc.org/ for more.</help-text>
                     <label>UNSPSC commodity code</label>
                     <label lang="de-DE">UNSPSC Warenkennzeichnungscode</label>
+                    <allow-cart-expose>true</allow-cart-expose>
+                </text>
+            </fields>
+        </custom-field-set>
+        <custom-field-set>
+            <name>swag_braintree_app_order</name>
+            <label>Braintree by PayPal</label>
+            <label lang="de-DE">Braintree von PayPal</label>
+            <related-entities>
+                <order/>
+            </related-entities>
+            <fields>
+                <text name="swag_braintree_app_custom_fields">
+                    <position>1</position>
+                    <placeholder>JSON object, e.g. {"someField":"true"}</placeholder>
+                    <placeholder lang="de-DE">JSON Objekt, z.B. {"someField":"true"}</placeholder>
+                    <help-text>See https://developer.paypal.com/braintree/articles/control-panel/custom-fields for more information</help-text>
+                    <label>JSON object containing Braintree Custom Fields</label>
+                    <label lang="de-DE">JSON Objekt mit Braintree Custom Fields</label>
                     <allow-cart-expose>true</allow-cart-expose>
                 </text>
             </fields>

--- a/templates/manifest.xml.twig
+++ b/templates/manifest.xml.twig
@@ -12,7 +12,7 @@
         <description lang="de-DE">Mit der App “PayPal Braintree” App von Shopware integrierst du ab sofort eine der beliebtesten Lösungen für Kreditkartenzahlungen ganz einfach in deinen Shop.</description>
         <author>shopware AG</author>
         <copyright>(c) by shopware AG</copyright>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
         <icon>Resources/plugin.webp</icon>
         <license>MIT</license>
         <compatibility>~6.6.0</compatibility>
@@ -65,6 +65,25 @@
                     <help-text>United Nations Standard Products and Services Code (UNSPSC). Search https://www.unspsc.org/ for more.</help-text>
                     <label>UNSPSC commodity code</label>
                     <label lang="de-DE">UNSPSC Warenkennzeichnungscode</label>
+                    <allow-cart-expose>true</allow-cart-expose>
+                </text>
+            </fields>
+        </custom-field-set>
+        <custom-field-set>
+            <name>swag_braintree_app_order</name>
+            <label>Braintree by PayPal</label>
+            <label lang="de-DE">Braintree von PayPal</label>
+            <related-entities>
+                <order/>
+            </related-entities>
+            <fields>
+                <text name="swag_braintree_app_custom_fields">
+                    <position>1</position>
+                    <placeholder>JSON object, e.g. {"someField":"true"}</placeholder>
+                    <placeholder lang="de-DE">JSON Objekt, z.B. {"someField":"true"}</placeholder>
+                    <help-text>See https://developer.paypal.com/braintree/articles/control-panel/custom-fields for more information</help-text>
+                    <label>JSON object containing Braintree Custom Fields</label>
+                    <label lang="de-DE">JSON Objekt mit Braintree Custom Fields</label>
                     <allow-cart-expose>true</allow-cart-expose>
                 </text>
             </fields>


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
Braintree has a [rule manager](https://developer.paypal.com/braintree/docs/guides/3d-secure/rules-manager/javascript/v3/#custom-fields), allowing for custom 3DS rules applied. Rules can be applied based on custom fields you pass to the `verifyCard(...)` or `transaction->sale(...)` call, where the latter seems more for data collection purposes.

### 2. What does this change do, exactly?
- Add the possibility to add custom fields via Twig, app hooks and JS
- Add the possibility to add custom fields via a custom field of the OrderEntity

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.