### PR TITLE
fix: improve headless support

### DIFF
--- a/src/Controller/StorefrontController.php
+++ b/src/Controller/StorefrontController.php
@@ -3,8 +3,8 @@
 namespace Swag\Braintree\Controller;
 
 use Braintree\Gateway;
+use Shopware\App\SDK\Context\Storefront\StorefrontAction;
 use Swag\Braintree\Braintree\Util\SalesChannelConfigService;
-use Swag\Braintree\Entity\ShopEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
-#[Route(path: '/api')]
+#[Route(path: '/api', format: 'json')]
 class StorefrontController extends AbstractController
 {
     public function __construct(
@@ -29,17 +29,18 @@ class StorefrontController extends AbstractController
         methods: [Request::METHOD_POST]
     )]
     public function getClientToken(
-        ShopEntity $shop,
+        StorefrontAction $storefrontAction,
         #[MapQueryParameter(name: 'currency-id')]
-        string $currencyId,
+        ?string $currencyId = null,
         #[MapQueryParameter(name: 'sales-channel-id')]
-        string $salesChannelId,
+        ?string $salesChannelId = null,
     ): Response {
-        $merchantAccount = $this->salesChannelConfigService->getMerchantId($salesChannelId, $currencyId, $shop);
+        $currencyId ??= $storefrontAction->claims->getCurrencyId();
+        $salesChannelId ??= $storefrontAction->claims->getSalesChannelId();
 
-        $token = $this->gateway->clientToken()->generate([
-            'merchantAccountId' => $merchantAccount,
-        ]);
+        $merchantAccount = $this->salesChannelConfigService->getMerchantId($salesChannelId, $currencyId, $storefrontAction->shop);
+
+        $token = $this->gateway->clientToken()->generate(['merchantAccountId' => $merchantAccount]);
 
         return new JsonResponse(['token' => $token]);
     }

--- a/tests/unit/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Controller/StorefrontControllerTest.php
@@ -7,12 +7,19 @@ namespace Swag\Braintree\Tests\Unit\Controller;
 use Braintree\ClientTokenGateway;
 use Braintree\Gateway;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\App\SDK\Context\Storefront\StorefrontAction;
+use Shopware\App\SDK\Context\Storefront\StorefrontClaims;
+use Shopware\App\SDK\Framework\Collection;
 use Swag\Braintree\Braintree\Util\SalesChannelConfigService;
 use Swag\Braintree\Controller\StorefrontController;
 use Swag\Braintree\Entity\ShopEntity;
 
+/**
+ * @phpstan-import-type StorefrontClaimsArray from StorefrontClaims
+ */
 #[CoversClass(StorefrontController::class)]
 class StorefrontControllerTest extends TestCase
 {
@@ -32,7 +39,13 @@ class StorefrontControllerTest extends TestCase
         );
     }
 
-    public function testGetClientTokenReturnsJsonResponseWithToken(): void
+    /**
+     * @param StorefrontClaimsArray $queryParams
+     * @param StorefrontClaimsArray $claims
+     * @param StorefrontClaimsArray $expected
+     */
+    #[DataProvider('providerGetClientToken')]
+    public function testGetClientToken(array $queryParams, array $claims, array $expected): void
     {
         $clientToken = $this->createMock(ClientTokenGateway::class);
         $clientToken
@@ -51,14 +64,43 @@ class StorefrontControllerTest extends TestCase
         $this->salesChannelConfigService
             ->expects(static::once())
             ->method('getMerchantId')
-            ->with('this-is-sales-channel-id', 'this-is-currency-id', $shop)
+            ->with($expected['salesChannelId'], $expected['currencyId'], $shop)
             ->willReturn('this-is-merchant-id');
 
-        $response = $this->controller->getClientToken($shop, 'this-is-currency-id', 'this-is-sales-channel-id');
+        $action = new StorefrontAction($shop, new StorefrontClaims($claims), new Collection());
+
+        $response = $this->controller->getClientToken($action, ...$queryParams);
 
         $json = \json_decode($response->getContent(), true);
 
         static::assertNotNull($json);
         static::assertSame(['token' => 'this-is-client-token'], $json);
+    }
+
+    public static function providerGetClientToken(): \Generator
+    {
+        yield 'with query params' => [
+            ['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'this-is-sales-channel-id'],
+            ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'claim-sales-channel-id'],
+            ['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'this-is-sales-channel-id'],
+        ];
+
+        yield 'without query params' => [
+            ['currencyId' => null, 'salesChannelId' => null],
+            ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'claim-sales-channel-id'],
+            ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'claim-sales-channel-id'],
+        ];
+
+        yield 'without sales channel id param' => [
+            ['currencyId' => 'this-is-currency-id', 'salesChannelId' => null],
+            ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'claim-sales-channel-id'],
+            ['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'claim-sales-channel-id'],
+        ];
+
+        yield 'without currency id param' => [
+            ['currencyId' => null, 'salesChannelId' => 'this-is-sales-channel-id'],
+            ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'claim-sales-channel-id'],
+            ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'this-is-sales-channel-id'],
+        ];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
Headless behaviour e.g. via composable frontends can be improved.

### 2. What does this change do, exactly?
Use `StorefrontAction` to extract currencyId and salesChannelId

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.