### PR TITLE
fix: missing account banner on all settings pages

### DIFF
--- a/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-currency.vue
+++ b/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-currency.vue
@@ -1,21 +1,5 @@
 <template>
 <div>
-    <mt-banner
-        v-if='missingAccount'
-        variant='attention'
-        class='sw-braintree-app-settings-currency__missing-account'
-        :closable='false'
-        :title='$t("settings.currency.missingAccountTitle")'
-    >
-        <i18n-t keypath='settings.currency.missingAccount' tag='span'>
-            <template #link>
-                <mt-link type='internal' @click='onPaymentMethodOverview'>
-                    {{ $t("settings.currency.missingAccountLink") }}
-                </mt-link>
-            </template>
-        </i18n-t>
-    </mt-banner>
-
     <mt-card
         :title='$t("settings.currency.table.title")'
         :is-loading='loading'
@@ -62,7 +46,7 @@ import type { PropType } from 'vue';
 import { defineComponent, inject } from 'vue';
 import SwBraintreeAppTable from '../base/sw-braintree-app-table.vue';
 import SwBraintreeAppCurrencyMappingSelect from './sw-braintree-app-settings-currency-mapping-select.vue';
-import { MtCard, MtBanner, MtLink } from '@shopware-ag/meteor-component-library';
+import { MtCard } from '@shopware-ag/meteor-component-library';
 import * as sw from '@shopware-ag/meteor-admin-sdk';
 import { DefaultCurrencyMappingEntity } from '@/resources/entities';
 import { registerSaveHandler } from '@/resources/inject-keys';
@@ -80,8 +64,6 @@ export default defineComponent({
         SwBraintreeAppTable,
         MtCard,
         SwBraintreeAppCurrencyMappingSelect,
-        MtBanner,
-        MtLink,
     },
 
     props: {
@@ -89,6 +71,11 @@ export default defineComponent({
             type: String as PropType<string | null>,
             required: false,
             default: null,
+        },
+        missingAccount: {
+            type: Boolean,
+            required: false,
+            default: false,
         },
     },
 
@@ -99,7 +86,6 @@ export default defineComponent({
     },
 
     data(): {
-        missingAccount: boolean,
         hasChanges: boolean,
         loading: boolean,
         loadingInputs: boolean,
@@ -110,7 +96,6 @@ export default defineComponent({
         currencies: Currencies,
     } {
         return {
-            missingAccount: false,
             hasChanges: false,
             loading: true,
             loadingInputs: true,
@@ -178,10 +163,8 @@ export default defineComponent({
                 .then((merchantAccounts) => {
                     if (merchantAccounts.length > 0)
                         this.merchantAccounts = merchantAccounts;
-                    else
-                        this.missingAccount = true;
                 })
-                .catch(() => {this.missingAccount = true;});
+                .catch(() => {});
         },
 
         async getCurrencyMappings(salesChannelId: string | null = null): Promise<void> {
@@ -300,12 +283,6 @@ export default defineComponent({
             if (this.mappings[idx].id) this.deletedMappings.push({ ...this.mappings[idx] });
             else this.mappings.splice(idx, 1);
         },
-
-        onPaymentMethodOverview() {
-            void sw.window.routerPush({
-                name: 'sw.settings.payment.overview',
-            });
-        },
     },
 });
 </script>
@@ -344,14 +321,6 @@ export default defineComponent({
     &__merchant-account-select:not(.is-inheritance) {
         .mt-field__label {
             display: none;
-        }
-    }
-
-    &__missing-account {
-        max-width: 960px;
-
-        &.mt-banner {
-            margin-bottom: var(--scale-size-40);
         }
     }
 }

--- a/assets/src/i18n/en-GB.json
+++ b/assets/src/i18n/en-GB.json
@@ -65,7 +65,7 @@
     },
     "currency": {
       "missingAccountTitle": "Missing information",
-      "missingAccount": "Please link your Braintree account in the {link}",
+      "missingAccount": "Please check and link your Braintree account in the {link}",
       "missingAccountLink": "payment methods overview",
       "table": {
         "title": "Currency mapping",

--- a/assets/src/views/sw-braintree-app-config-page.vue
+++ b/assets/src/views/sw-braintree-app-config-page.vue
@@ -50,7 +50,6 @@
             </mt-button>
 
             <mt-link
-                v-if='connection?.connectionStatus === "active"'
                 type='internal'
                 @click='onSettingsLinkCicked("swBraintreeAppSettingsCurrency")'
             >

--- a/assets/src/views/sw-braintree-app-settings-page.vue
+++ b/assets/src/views/sw-braintree-app-settings-page.vue
@@ -33,9 +33,26 @@
         </div>
     </mt-card>
 
+    <mt-banner
+        v-if='missingAccount'
+        variant='attention'
+        class='sw-braintree-app-settings-page__missing-account'
+        :closable='false'
+        :title='$t("settings.currency.missingAccountTitle")'
+    >
+        <i18n-t keypath='settings.currency.missingAccount' tag='span'>
+            <template #link>
+                <mt-link type='internal' @click='onPaymentMethodOverview'>
+                    {{ $t("settings.currency.missingAccountLink") }}
+                </mt-link>
+            </template>
+        </i18n-t>
+    </mt-banner>
+
     <component
         :is='activeTabComponent'
         :sales-channel-id='salesChannelId'
+        :missing-account='missingAccount'
     />
 </sw-card-view-content>
 </template>
@@ -43,7 +60,7 @@
 
 <script lang='ts'>
 import { type Component, defineComponent } from 'vue';
-import { MtCard, MtButton, MtTabs, MtLink } from '@shopware-ag/meteor-component-library';
+import { MtCard, MtButton, MtTabs, MtLink, MtBanner } from '@shopware-ag/meteor-component-library';
 import SwBraintreeAppSettingsGeneral from '@/component/sw-braintree-app-settings/sw-braintree-app-settings-general.vue';
 import SwBraintreeAppSettingsCurrency from '@/component/sw-braintree-app-settings/sw-braintree-app-settings-currency.vue';
 import SwSalesChannelSwitch from '@/component/base/sw-sales-channel-switch.vue';
@@ -97,6 +114,7 @@ export default defineComponent({
         MtButton,
         MtTabs,
         MtLink,
+        MtBanner,
     },
 
     data(): {
@@ -105,6 +123,7 @@ export default defineComponent({
         salesChannelId: string | null,
         tabs: TabItem[],
         saveHandler: SaveHandler[],
+        connection?: BraintreeConnection,
     } {
         return {
             activeTab: settingsTabHandler.get(),
@@ -121,6 +140,7 @@ export default defineComponent({
                     label: this.$t('settings.tabs.currencyLabel'),
                 },
             ],
+            connection: undefined,
         };
     },
 
@@ -128,9 +148,25 @@ export default defineComponent({
         activeTabComponent(): Component {
             return tabs[this.activeTab];
         },
+
+        missingAccount(): boolean {
+            return !!this.connection && this.connection.connectionStatus !== 'active';
+        },
+    },
+
+    created(): void {
+        this.getConnectionStatus();
     },
 
     methods: {
+        async getConnectionStatus(): Promise<void> {
+            return this.$api.get<BraintreeConnection>('/config/status')
+                .then((connection) => {
+                    this.connection = connection;
+                })
+                .catch((e) => this.$notify.error('fetch_account_status', e));
+        },
+
         async onNewItemActive(item: keyof typeof tabs): Promise<void> {
             settingsTabHandler.set(item);
             this.activeTab = item;
@@ -146,6 +182,12 @@ export default defineComponent({
         },
 
         onConfigLinkCicked(): void {
+            void sw.window.routerPush({
+                name: 'sw.settings.payment.overview',
+            });
+        },
+
+        onPaymentMethodOverview() {
             void sw.window.routerPush({
                 name: 'sw.settings.payment.overview',
             });
@@ -169,6 +211,14 @@ body {
 
         .mt-link {
             font-size: var(--font-size-xs);
+        }
+    }
+
+    &__missing-account {
+        max-width: 960px;
+
+        &.mt-banner {
+            margin-bottom: var(--scale-size-40);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
After installing the app, the Braintree extension page is properly the first you go to. For a smoother experience you should be guided to link your account, which is already the case for the "Currency mapping" tab but not the others.

### 2. What does this change do, exactly?
Move the missing account banner to the settings page instead of the "Currency mapping" tab.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.