### PR TITLE
feat: add transaction authorization support

### DIFF
--- a/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-general.vue
+++ b/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-general.vue
@@ -4,23 +4,35 @@
     :title='$t("settings.general.title")'
     :is-loading='loading'
 >
-    <div class='sw-braintree-app-settings-general__threeDSecuredEnforced'>
+    <div class='content'>
         <mt-switch
-            class='sw-braintree-app-settings-general__threeDSecureEnforced__input'
+            class='sw-braintree-app-settings-general__threeDSecureEnforced'
             bordered
             :label='$t("settings.general.threeDSecureEnforced.label")'
             :checked='activeConfig?.threeDSecureEnforced ?? undefined'
             :is-inherited='isFieldInherited("threeDSecureEnforced")'
             :is-inheritance-field='!!salesChannelId'
-            :help-text='$t("settings.general.threeDSecureToolTip")'
+            :help-text='$t("settings.general.threeDSecureEnforced.tooltip")'
             @change='activeConfig.threeDSecureEnforced = !activeConfig.threeDSecureEnforced'
             @inheritance-remove='onRemove3DSInheritance()'
             @inheritance-restore='onRestoreInheritance("threeDSecureEnforced")'
         />
-    </div>
-    <div class='sw-braintree-app-settings-general__shipsFromPostalCode'>
+
+        <mt-switch
+            class='sw-braintree-app-settings-general__submitForSettlement'
+            bordered
+            :label='$t("settings.general.submitForSettlement.label")'
+            :checked='activeConfig?.submitForSettlement ?? true'
+            :is-inherited='isFieldInherited("submitForSettlement")'
+            :is-inheritance-field='!!salesChannelId'
+            :help-text='$t("settings.general.submitForSettlement.tooltip")'
+            @change='activeConfig.submitForSettlement = !activeConfig.submitForSettlement'
+            @inheritance-remove='onRemove3DSInheritance()'
+            @inheritance-restore='onRestoreInheritance("submitForSettlement")'
+        />
+
         <mt-text-field
-            class='sw-braintree-app-settings-general__shipsFromPostalCode__input'
+            class='sw-braintree-app-settings-general__shipsFromPostalCode'
             :label='$t("settings.general.shipsFromPostalCode.label")'
             :placeholder='$t("settings.general.shipsFromPostalCode.placeholder")'
             :is-inherited='isFieldInherited("shipsFromPostalCode")'
@@ -147,11 +159,10 @@ export default defineComponent({
 
 <style lang='scss'>
 .sw-braintree-app-settings-general {
-    display: flex;
-    flex-direction: column;
-
-    &__shipsFromPostalCode {
-        margin-top: var(--scale-size-24);
+    .content {
+        display: flex;
+        flex-direction: column;
+        gap: var(--scale-size-24);
     }
 }
 </style>

--- a/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-general.vue
+++ b/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-general.vue
@@ -9,12 +9,12 @@
             class='sw-braintree-app-settings-general__threeDSecureEnforced'
             bordered
             :label='$t("settings.general.threeDSecureEnforced.label")'
-            :checked='activeConfig?.threeDSecureEnforced ?? undefined'
+            :checked='activeConfig.threeDSecureEnforced ?? false'
             :is-inherited='isFieldInherited("threeDSecureEnforced")'
             :is-inheritance-field='!!salesChannelId'
             :help-text='$t("settings.general.threeDSecureEnforced.tooltip")'
-            @change='activeConfig.threeDSecureEnforced = !activeConfig.threeDSecureEnforced'
-            @inheritance-remove='onRemove3DSInheritance()'
+            @change='activeConfig.threeDSecureEnforced = $event'
+            @inheritance-remove='onRemoveInheritance("threeDSecureEnforced")'
             @inheritance-restore='onRestoreInheritance("threeDSecureEnforced")'
         />
 
@@ -22,12 +22,12 @@
             class='sw-braintree-app-settings-general__submitForSettlement'
             bordered
             :label='$t("settings.general.submitForSettlement.label")'
-            :checked='activeConfig?.submitForSettlement ?? true'
+            :checked='activeConfig.submitForSettlement ?? true'
             :is-inherited='isFieldInherited("submitForSettlement")'
             :is-inheritance-field='!!salesChannelId'
             :help-text='$t("settings.general.submitForSettlement.tooltip")'
-            @change='activeConfig.submitForSettlement = !activeConfig.submitForSettlement'
-            @inheritance-remove='onRemove3DSInheritance()'
+            @change='activeConfig.submitForSettlement = $event'
+            @inheritance-remove='onRemoveInheritance("submitForSettlement")'
             @inheritance-restore='onRestoreInheritance("submitForSettlement")'
         />
 
@@ -89,12 +89,12 @@ export default defineComponent({
         },
 
         activeConfig(): ConfigEntity {
-            return this.config[this.stringifySalesChannelId] ?? DefaultConfigEntity(this.salesChannelId);
+            return this.config[this.stringifySalesChannelId] ?? {};
         },
     },
 
     watch: {
-        salesChannelId(){
+        salesChannelId() {
             void this.getConfig();
         },
     },
@@ -105,28 +105,41 @@ export default defineComponent({
     },
 
     methods: {
-        async getConfig(): Promise<void> {
-            if(this.config[this.stringifySalesChannelId]) return;
+        async getConfig(cached: boolean = true): Promise<void> {
+            if(cached && this.config[this.stringifySalesChannelId]) return;
+
+            this.loading = true;
 
             return this.$api.get<ConfigEntity>('/entity/by-sales-channel/config/' + this.stringifySalesChannelId)
                 .then((config) => {
-                    this.config[this.stringifySalesChannelId] = config;
-                    this.loading = false;
+                    this.config[String(config.salesChannelId)] = config;
+                    
+                    // add new config parameters
                     if (this.config['null']?.threeDSecureEnforced === null)
                         this.config['null'].threeDSecureEnforced = false;
 
+                    if (this.config['null']?.submitForSettlement === null)
+                        this.config['null'].submitForSettlement = false;
+
+                    this.loading = false;
                 })
                 .catch((e) => this.$notify.error('fetch_settings', e));
         },
 
         async updateConfig(): Promise<void> {
-            return this.$api.patch<ConfigEntity>('/entity/config', Object.values(this.config))
-                .then(() => {
-                    this.config = {};
-                    void this.getConfig();
-                    this.$notify.success('save_settings');
-                })
-                .catch((e) => this.$notify.error('save_settings', e));
+            this.loading = true;
+            
+            try {
+                await this.$api.patch<ConfigEntity>('/entity/config', Object.values(this.config));
+
+                // only preserve the active config to avoid flickering of toggles due to default values
+                this.config = { [this.stringifySalesChannelId]: this.activeConfig };
+                this.$notify.success('save_settings');
+                await this.getConfig(false);
+            } catch (e) {
+                this.$notify.error('save_settings', e);
+                this.loading = false;
+            }
         },
 
         isFieldInherited(key: keyof ConfigEntity): boolean {
@@ -134,10 +147,6 @@ export default defineComponent({
                 return false;
 
             return this.activeConfig[key] === null;
-        },
-
-        onRemove3DSInheritance() {
-            this.activeConfig['threeDSecureEnforced'] = this.config['null']?.['threeDSecureEnforced'] ?? DefaultConfigEntity(this.salesChannelId)['threeDSecureEnforced'];
         },
 
         onRemovePostalCodeInheritance() {

--- a/assets/src/i18n/en-GB.json
+++ b/assets/src/i18n/en-GB.json
@@ -55,12 +55,16 @@
     "general": {
       "title": "General",
       "threeDSecureEnforced": {
-        "label": "Only accept transactions with 3D Secure"
+        "label": "Only accept transactions with 3D Secure",
+        "tooltip": "Transaction will not be accepted, if 3D Secure is not available"
       },
-      "threeDSecureToolTip": "Transaction will not be accepted, if 3D Secure is not available",
       "shipsFromPostalCode": {
         "label": "Sender shipping address postal code",
         "placeholder": "e.g. 48268"
+      },
+      "submitForSettlement": {
+        "label": "Submit for settlement immediately",
+        "tooltip": "If this option is enabled, transactions will be submitted for settlement immediately after the order got placed. If it is disabled, transactions will only be authorized and will need to be settled manually in your Braintree account."
       }
     },
     "currency": {

--- a/assets/src/resources/entities.ts
+++ b/assets/src/resources/entities.ts
@@ -2,6 +2,7 @@ export const DefaultConfigEntity = (salesChannelId?: string | null): ConfigEntit
     id: null,
     shop: '',
     threeDSecureEnforced: false,
+    submitForSettlement: true,
     shipsFromPostalCode: null,
     salesChannelId: salesChannelId ?? null,
     createdAt: (new Date()).toISOString(),

--- a/assets/src/service/notify.ts
+++ b/assets/src/service/notify.ts
@@ -17,7 +17,7 @@ export class Notify {
         const clone = response.clone();
         const message = await response
             .json()
-            .then((json) => String(json?.message || json))
+            .then(this.formatError.bind(this))
             .catch(() => clone.text());
 
         void sw.notification.dispatch({
@@ -33,5 +33,15 @@ export class Notify {
             title: this.i18n.global.t('notification.success'),
             message: this.i18n.global.t(`success.${String(code)}`),
         });
+    }
+
+    private formatError(json: any): string {
+        if (typeof json !== 'object') 
+            return String(json);
+
+        if (json?.message || json?.detail) 
+            return String(json.message || json.detail);
+
+        return String(JSON.stringify(json));
     }
 }

--- a/assets/src/types/global.ts
+++ b/assets/src/types/global.ts
@@ -22,6 +22,7 @@ declare global {
         id: string | null,
         shop: string,
         threeDSecureEnforced: boolean | null,
+        submitForSettlement: boolean | null,
         shipsFromPostalCode: string | null,
         salesChannelId: string | null,
         createdAt: string,

--- a/migrations/Version20250714125845SubmitForSettlement.php
+++ b/migrations/Version20250714125845SubmitForSettlement.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250714125845SubmitForSettlement extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE config ADD submit_for_settlement TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE config DROP submit_for_settlement');
+    }
+}

--- a/src/Braintree/Payment/BraintreePaymentService.php
+++ b/src/Braintree/Payment/BraintreePaymentService.php
@@ -56,7 +56,9 @@ class BraintreePaymentService
             'discountAmount' => $this->orderInformationService->extractDiscountAmount($payment),
             'lineItems' => $this->orderInformationService->extractLineItems($payment),
             'merchantAccountId' => $merchantId,
-            'options' => ['submitForSettlement' => true],
+            'options' => [
+                'submitForSettlement' => $this->salesChannelConfigService->submitForSettlement($salesChannelId, $payment->shop),
+            ],
             'paymentMethodNonce' => $nonce,
             'purchaseOrderNumber' => $payment->order->getOrderNumber(),
             'shipping' => $shipping['address'],

--- a/src/Braintree/Util/SalesChannelConfigService.php
+++ b/src/Braintree/Util/SalesChannelConfigService.php
@@ -52,6 +52,25 @@ class SalesChannelConfigService
         return false;
     }
 
+    public function submitForSettlement(string $salesChannelId, ShopInterface $shop): bool
+    {
+        $configs = $this->configRepository->findBy(['salesChannelId' => [null, $salesChannelId], 'shop' => $shop]);
+
+        foreach ($configs as $config) {
+            $configs[$config->getSalesChannelId()] = $config;
+        }
+
+        if (isset($configs[$salesChannelId]) && $configs[$salesChannelId]->isSubmitForSettlement() !== null) {
+            return $configs[$salesChannelId]->isSubmitForSettlement();
+        }
+
+        if (isset($configs[null]) && $configs[null]->isSubmitForSettlement() !== null) {
+            return $configs[null]->isSubmitForSettlement();
+        }
+
+        return true;
+    }
+
     public function getShipsFromPostalCode(string $salesChannelId, ShopInterface $shop): string
     {
         $configs = $this->configRepository->findBy(['salesChannelId' => [null, $salesChannelId], 'shop' => $shop]);

--- a/src/Entity/ConfigEntity.php
+++ b/src/Entity/ConfigEntity.php
@@ -29,6 +29,10 @@ class ConfigEntity implements EntityInterface
     private ?bool $threeDSecureEnforced = null;
 
     #[Groups(groups: ['admin-write'])]
+    #[ORM\Column(type: Types::BOOLEAN, nullable: true)]
+    private ?bool $submitForSettlement = null;
+
+    #[Groups(groups: ['admin-write'])]
     #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
     private ?string $shipsFromPostalCode = null;
 
@@ -40,6 +44,18 @@ class ConfigEntity implements EntityInterface
     public function setThreeDSecureEnforced(?bool $threeDSecureEnforced): self
     {
         $this->threeDSecureEnforced = $threeDSecureEnforced;
+
+        return $this;
+    }
+
+    public function isSubmitForSettlement(): ?bool
+    {
+        return $this->submitForSettlement;
+    }
+
+    public function setSubmitForSettlement(?bool $submitForSettlement): self
+    {
+        $this->submitForSettlement = $submitForSettlement;
 
         return $this;
     }

--- a/tests/unit/Braintree/Payment/BraintreePaymentServiceTest.php
+++ b/tests/unit/Braintree/Payment/BraintreePaymentServiceTest.php
@@ -59,6 +59,7 @@ class BraintreePaymentServiceTest extends TestCase
         $salesChannelConfigService = $this->createMock(SalesChannelConfigService::class);
         $salesChannelConfigService->method('getMerchantId')->willReturn('this-is-merchant-id');
         $salesChannelConfigService->method('isThreeDSecureEnforced')->willReturn(true);
+        $salesChannelConfigService->method('submitForSettlement')->willReturn(true);
 
         $this->transactionRepository = $this->createMock(TransactionRepository::class);
 

--- a/tests/unit/Braintree/Util/SalesChannelConfigServiceTest.php
+++ b/tests/unit/Braintree/Util/SalesChannelConfigServiceTest.php
@@ -263,7 +263,7 @@ class SalesChannelConfigServiceTest extends TestCase
 
         $defaultConfig = (new ConfigEntity())
             ->setSalesChannelId(null)
-            ->setThreeDSecureEnforced(false);
+            ->setThreeDSecureEnforced(null);
 
         $this->configRepository
             ->expects(static::once())
@@ -406,5 +406,135 @@ class SalesChannelConfigServiceTest extends TestCase
         );
 
         static::assertSame('', $postalCode);
+    }
+
+    public function testSubmitForSettlementBothButSeperateIsNull(): void
+    {
+        $config = (new ConfigEntity())
+            ->setSalesChannelId('this-is-sales-channel-id')
+            ->setSubmitForSettlement(null);
+
+        $defaultConfig = (new ConfigEntity())
+            ->setSalesChannelId(null)
+            ->setSubmitForSettlement(true);
+
+        $this->configRepository
+            ->expects(static::once())
+            ->method('findBy')
+            ->willReturn([$config, $defaultConfig]);
+
+        $submitForSettlement = $this->salesChannelConfigService->submitForSettlement(
+            'this-is-sales-channel-id',
+            $this->shop
+        );
+
+        static::assertTrue($submitForSettlement);
+    }
+
+    public function testSubmitForSettlementBothReturnsSeperate(): void
+    {
+        $config = (new ConfigEntity())
+            ->setSalesChannelId('this-is-sales-channel-id')
+            ->setSubmitForSettlement(true);
+
+        $defaultConfig = (new ConfigEntity())
+            ->setSalesChannelId(null)
+            ->setSubmitForSettlement(false);
+
+        $this->configRepository
+            ->expects(static::once())
+            ->method('findBy')
+            ->willReturn([$config, $defaultConfig]);
+
+        $submitForSettlement = $this->salesChannelConfigService->submitForSettlement(
+            'this-is-sales-channel-id',
+            $this->shop
+        );
+
+        static::assertTrue($submitForSettlement);
+    }
+
+    public function testSubmitForSettlementOnlySeperate(): void
+    {
+        $config = (new ConfigEntity())
+            ->setSalesChannelId('this-is-sales-channel-id')
+            ->setSubmitForSettlement(true);
+
+        $this->configRepository
+            ->expects(static::once())
+            ->method('findBy')
+            ->willReturn([$config]);
+
+        $submitForSettlement = $this->salesChannelConfigService->submitForSettlement(
+            'this-is-sales-channel-id',
+            $this->shop
+        );
+
+        static::assertTrue($submitForSettlement);
+    }
+
+    public function testSubmitForSettlementOnlyDefault(): void
+    {
+        $defaultConfig = (new ConfigEntity())
+            ->setSalesChannelId(null)
+            ->setSubmitForSettlement(false);
+
+        $this->configRepository
+            ->expects(static::once())
+            ->method('findBy')
+            ->willReturn([$defaultConfig]);
+
+        $submitForSettlement = $this->salesChannelConfigService->submitForSettlement(
+            'this-is-sales-channel-id',
+            $this->shop
+        );
+
+        static::assertFalse($submitForSettlement);
+    }
+
+    public function testSubmitForSettlementWithNone(): void
+    {
+        $shop = $this->shop;
+        $this->configRepository
+            ->expects(static::once())
+            ->method('findBy')
+            ->with(static::callback(static function (array $criteria) use ($shop): bool {
+                static::assertContains('this-is-sales-channel-id', $criteria['salesChannelId']);
+                static::assertContains(null, $criteria['salesChannelId']);
+                static::assertEquals($shop, $criteria['shop']);
+
+                return true;
+            }))
+            ->willReturn([]);
+
+        $submitForSettlement = $this->salesChannelConfigService->submitForSettlement(
+            'this-is-sales-channel-id',
+            $this->shop
+        );
+
+        static::assertTrue($submitForSettlement);
+    }
+
+    public function testSubmitForSettlementWithBothNull(): void
+    {
+        $config = (new ConfigEntity())
+            ->setSalesChannelId('this-is-sales-channel-id')
+            ->setSubmitForSettlement(null);
+
+        $defaultConfig = (new ConfigEntity())
+            ->setSalesChannelId(null)
+            ->setSubmitForSettlement(null);
+
+        $this->configRepository
+            ->expects(static::once())
+            ->method('findBy')
+            ->willReturn([$config, $defaultConfig]);
+
+        $submitForSettlement = $this->salesChannelConfigService->submitForSettlement(
+            'this-is-sales-channel-id',
+            $this->shop
+        );
+
+        static::assertTrue($submitForSettlement);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
Sometimes you want to just authorize but not capture the payment.

### 2. What does this change do, exactly?
Add the option to only authorize a transaction (`submitForSettlement = false`). The default behaviour is still to immediately capture.
Additionally, the transaction detail page links to the Braintree transaction page, as we don't provide a UI to capture an authorized transaction. 

### 3. Todos
- [ ] Shopware transaction status needs to be set to "authorized"
- [ ] Shopware transaction status needs to be synced with Braintree
- [ ] Braintree transaction (& report) table needs to be updated accordingly

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.