### PR TITLE
feat: transaction linking

### DIFF
--- a/assets/src/component/base/sw-status-indicator.vue
+++ b/assets/src/component/base/sw-status-indicator.vue
@@ -71,5 +71,31 @@ export default defineComponent({
             color: var(--color-green-500);
         }
     }
+
+    &.warning {
+        background: var(--color-orange-50);
+        border-color: var(--color-orange-200);
+
+        .sw-status__indicator {
+            background: var(--color-orange-500);
+        }
+
+        .sw-status__text {
+            color: var(--color-orange-500);
+        }
+    }
+
+    &.danger {
+        background: var(--color-red-50);
+        border-color: var(--color-red-200);
+
+        .sw-status__indicator {
+            background: var(--color-red-500);
+        }
+
+        .sw-status__text {
+            color: var(--color-red-500);
+        }
+    }
 }
 </style>

--- a/assets/src/component/base/sw-status-indicator.vue
+++ b/assets/src/component/base/sw-status-indicator.vue
@@ -77,11 +77,11 @@ export default defineComponent({
         border-color: var(--color-orange-200);
 
         .sw-status__indicator {
-            background: var(--color-orange-500);
+            background: var(--color-orange-600);
         }
 
         .sw-status__text {
-            color: var(--color-orange-500);
+            color: var(--color-orange-600);
         }
     }
 

--- a/assets/src/i18n/en-GB.json
+++ b/assets/src/i18n/en-GB.json
@@ -81,6 +81,9 @@
     "title": "Braintree by PayPal",
     "emptyStateTitle": "No braintree transaction found",
     "emptyStateDescription": "This order was not handled through Braintree",
+    "invalidEmptyStateTitle": "No braintree transaction found",
+    "invalidEmptyStateDescription": "Transaction was placed by another account or sandbox mode enabled | Transaction was placed by another account or sandbox mode disabled",
+    "transactionLink": "View and edit transaction in Braintree",
     "body": {
       "customerIdTitle": "Customer ID",
       "customerIdEmptyLabel": "No customer ID",

--- a/assets/src/i18n/en-GB.json
+++ b/assets/src/i18n/en-GB.json
@@ -80,9 +80,7 @@
     "tabLabel": "Braintree",
     "title": "Braintree by PayPal",
     "emptyStateTitle": "No braintree transaction found",
-    "emptyStateDescription": "This order was not handled through Braintree",
-    "invalidEmptyStateTitle": "No braintree transaction found",
-    "invalidEmptyStateDescription": "Transaction was placed by another account or sandbox mode enabled | Transaction was placed by another account or sandbox mode disabled",
+    "emptyStateDescription": "This order was not handled through Braintree or was done by a different Braintree account.",
     "transactionLink": "View and edit transaction in Braintree",
     "body": {
       "customerIdTitle": "Customer ID",

--- a/assets/src/location/index.ts
+++ b/assets/src/location/index.ts
@@ -37,7 +37,6 @@ export async function addLocations(paymentMethod: EntitySchema.Entity<'payment_m
             component: 'card',
             positionId: 'swag-braintree-app-order-transaction-detail',
             props: {
-                title: i18n.global.t('orderTransactionDetail.title'),
                 locationId: 'swag-braintree-app-order-transaction-detail-position-before',
             },
         }),

--- a/assets/src/views/sw-braintree-app-order-transaction-detail.vue
+++ b/assets/src/views/sw-braintree-app-order-transaction-detail.vue
@@ -21,19 +21,11 @@
     </div>
 
     <mt-empty-state
-        v-else-if='!transaction && !swTransactionIds'
+        v-else-if='!transaction'
         class='empty-state'
         icon='solid-shopping-basket'
         :headline='$t("orderTransactionDetail.emptyStateTitle")'
         :description='$t("orderTransactionDetail.emptyStateDescription")'
-    />
-
-    <mt-empty-state
-        v-else-if='!transaction'
-        class='empty-state'
-        icon='solid-shopping-basket'
-        :headline='$t("orderTransactionDetail.invalidEmptyStateTitle")'
-        :description='$t("orderTransactionDetail.invalidEmptyStateDescription", Number(shop?.braintreeSandbox))'
     />
 
     <div v-else class='transaction'>
@@ -211,14 +203,12 @@ export default defineComponent({
         loadingShop: boolean,
         transaction: BraintreeTransaction | null,
         shop: ShopEntity | null,
-        swTransactionIds: string[] | null,
     } {
         return {
             loadingTransaction: true,
             loadingShop: true,
             transaction: null,
             shop: null,
-            swTransactionIds: null,
         };
     },
 
@@ -280,16 +270,15 @@ export default defineComponent({
                 async ({ data }) => {
                     this.loadingTransaction = true;
                     this.transaction = null;
-                    this.swTransactionIds = null;
 
                     const criteria = (new Criteria())
                         .addFilter(Criteria.equals('orderId', (data as { id: string }).id));
 
                     const result = await Repository.search(criteria);
-                    this.swTransactionIds = result?.map((transaction) => transaction.id) ?? null;
+                    const transactionIds = result?.map((transaction) => transaction.id) || null;
 
                     void this.$api.post<BraintreeTransaction | null>('/transaction/newest', {
-                        transactions: this.swTransactionIds,
+                        transactions: transactionIds,
                     }).then((transaction) => {
                         if (!transaction)
                             return;

--- a/assets/src/views/sw-braintree-app-order-transaction-detail.vue
+++ b/assets/src/views/sw-braintree-app-order-transaction-detail.vue
@@ -1,15 +1,39 @@
 <template>
 <div class='sw-braintree-app-order-transaction-detail-page'>
-    <div v-if='loading' class='loader'>
+    <header class='header'>
+        <span class='title'>{{ $t('orderTransactionDetail.title') }}</span>
+        <mt-link
+            v-if='transactionLink'
+            type='external'
+            class='transaction__link'
+            as='a'
+            :to='transactionLink'
+            target='_blank'
+        >
+            {{ $t('orderTransactionDetail.transactionLink') }}
+        </mt-link>
+    </header>
+
+    <div class='divider' />
+
+    <div v-if='loadingTransaction && loadingShop' class='loader'>
         <mt-loader />
     </div>
 
     <mt-empty-state
-        v-else-if='showEmptyState'
+        v-else-if='!transaction && !swTransactionIds'
         class='empty-state'
         icon='solid-shopping-basket'
         :headline='$t("orderTransactionDetail.emptyStateTitle")'
         :description='$t("orderTransactionDetail.emptyStateDescription")'
+    />
+
+    <mt-empty-state
+        v-else-if='!transaction'
+        class='empty-state'
+        icon='solid-shopping-basket'
+        :headline='$t("orderTransactionDetail.invalidEmptyStateTitle")'
+        :description='$t("orderTransactionDetail.invalidEmptyStateDescription", Number(shop?.braintreeSandbox))'
     />
 
     <div v-else class='transaction'>
@@ -172,7 +196,7 @@
 <script lang='ts'>
 import { defineComponent } from 'vue';
 import * as sw from '@shopware-ag/meteor-admin-sdk';
-import { MtLoader, MtEmptyState } from '@shopware-ag/meteor-component-library';
+import { MtLoader, MtEmptyState, MtLink } from '@shopware-ag/meteor-component-library';
 import SwStatusIndicator from '@/component/base/sw-status-indicator.vue';
 
 const Criteria = sw.data.Classes.Criteria;
@@ -180,29 +204,31 @@ const Repository = sw.data.repository<'order_transaction'>('order_transaction');
 
 export default defineComponent({
     name: 'sw-braintree-app-order-transaction-detail',
-    components: { SwStatusIndicator, MtLoader, MtEmptyState },
+    components: { SwStatusIndicator, MtLoader, MtEmptyState, MtLink },
 
     data(): {
-        loading: boolean,
-        transaction: BraintreeTransaction,
+        loadingTransaction: boolean,
+        loadingShop: boolean,
+        transaction: BraintreeTransaction | null,
+        shop: ShopEntity | null,
+        swTransactionIds: string[] | null,
     } {
         return {
-            loading: true,
-            transaction: {} as BraintreeTransaction,
+            loadingTransaction: true,
+            loadingShop: true,
+            transaction: null,
+            shop: null,
+            swTransactionIds: null,
         };
     },
 
     computed: {
         amountNet(): number {
-            return parseFloat(this.transaction.amount) - parseFloat(this.transaction.shippingAmount);
-        },
-
-        showEmptyState(): boolean {
-            return !this.loading && !Object.keys(this.transaction).length;
+            return parseFloat(this.transaction?.amount ?? '') - parseFloat(this.transaction?.shippingAmount ?? '');
         },
 
         statusType(): StatusIndicatorType {
-            switch (this.transaction.status) {
+            switch (this.transaction?.status) {
                 case 'authorization_expired':
                 case 'settlement_declined':
                 case 'failed':
@@ -224,36 +250,53 @@ export default defineComponent({
                     return undefined;
             }
         },
+
+        transactionLink(): string {
+            if (this.loadingTransaction || this.loadingShop || !this.transaction || !this.shop)
+                return '';
+
+            return `https://${this.shop?.braintreeSandbox ? 'sandbox.' : ''}braintreegateway.com/merchants/${this.shop?.braintreeMerchantId}/transactions/${this.transaction?.id}`;
+        },
     },
 
     created() {
         this.loadBraintreeTransaction();
+        this.getShopConfig();
     },
 
     methods: {
-        loadBraintreeTransaction() {
-            this.loading = true;
+        async getShopConfig(): Promise<void> {
+            this.loadingShop = true;
 
+            return this.$api.get<ShopEntity>('/entity/shop')
+                .then((shop) => { this.shop = shop; })
+                .catch((e) => this.$notify.error('fetch_config', e))
+                .finally(() => { this.loadingShop = false; });
+        },
+
+        loadBraintreeTransaction() {
             void sw.data.subscribe(
                 'sw-order-detail-base__order',
-                async (response) => {
-                    const data = response.data as { id: string };
+                async ({ data }) => {
+                    this.loadingTransaction = true;
+                    this.transaction = null;
+                    this.swTransactionIds = null;
 
                     const criteria = (new Criteria())
-                        .addFilter(Criteria.equals('orderId', data.id));
+                        .addFilter(Criteria.equals('orderId', (data as { id: string }).id));
 
                     const result = await Repository.search(criteria);
-                    const transactionIds = result?.map((transaction) => transaction.id);
+                    this.swTransactionIds = result?.map((transaction) => transaction.id) ?? null;
 
                     void this.$api.post<BraintreeTransaction | null>('/transaction/newest', {
-                        transactions: transactionIds,
+                        transactions: this.swTransactionIds,
                     }).then((transaction) => {
                         if (!transaction)
                             return;
 
                         this.transaction = transaction;
                     }).finally(() => {
-                        this.loading = false;
+                        this.loadingTransaction = false;
                     });
                 },
                 {
@@ -272,6 +315,21 @@ export default defineComponent({
 
 <style scoped lang='scss'>
 .sw-braintree-app-order-transaction-detail-page {
+    .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: var(--font-size-s);
+        line-height: var(--font-line-height-s);
+
+        .title {
+            font-size: var(--font-size-m);
+            line-height: var(--font-line-height-m);
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-text-primary-default);
+        }
+    }
+
     background: var(--color-elevation-surface-default);
 
     .flex-column {


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
- `sw-status-indicator` was missing `wanring` and `danger` styles
- Quick link to braintree transaction page

### 2. What does this change do, exactly?+

<details><summary>Link to Braintree transaction</summary>

<img width="1000" height="585" alt="image" src="https://github.com/user-attachments/assets/077630e4-44c2-4785-9e68-fe5348c8bca4" />

</details>

<details><summary>sw-status-indicator</summary>

<img width="195" height="37" alt="image" src="https://github.com/user-attachments/assets/0a2590b7-5cac-409e-b2d1-1782eeb1f234" />

<img width="81" height="34" alt="image" src="https://github.com/user-attachments/assets/00b167be-ba5a-40e0-85fb-79b0c1f90171" />

</details>


### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.