### PR TITLE
fix: json api format

### DIFF
--- a/assets/src/service/notify.ts
+++ b/assets/src/service/notify.ts
@@ -17,7 +17,7 @@ export class Notify {
         const clone = response.clone();
         const message = await response
             .json()
-            .then((json) => String(json?.message || json))
+            .then(this.formatError.bind(this))
             .catch(() => clone.text());
 
         void sw.notification.dispatch({
@@ -33,5 +33,15 @@ export class Notify {
             title: this.i18n.global.t('notification.success'),
             message: this.i18n.global.t(`success.${String(code)}`),
         });
+    }
+
+    private formatError(json: any): string {
+        if (typeof json !== 'object') 
+            return String(json);
+
+        if (json?.message || json?.detail) 
+            return String(json.message || json.detail);
+
+        return String(JSON.stringify(json));
     }
 }

--- a/src/Controller/BraintreeConfigurationController.php
+++ b/src/Controller/BraintreeConfigurationController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
-#[Route(path: '/api')]
+#[Route(path: '/api', format: 'json')]
 class BraintreeConfigurationController extends AbstractController
 {
     public function __construct(

--- a/src/Controller/EntityController.php
+++ b/src/Controller/EntityController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
-#[Route(path: '/api')]
+#[Route(path: '/api', format: 'json')]
 class EntityController extends AbstractController
 {
     public function __construct(

--- a/src/Controller/GatewayController.php
+++ b/src/Controller/GatewayController.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
-#[Route(path: '/api/gateway', name: 'swag.braintree.api.gateway.')]
+#[Route(path: '/api/gateway', name: 'swag.braintree.api.gateway.', format: 'json')]
 class GatewayController extends AbstractController
 {
     public const CREDIT_CARD_TECHNICAL_NAME = 'payment_SwagBraintreeApp_credit_card';

--- a/src/Controller/PaymentController.php
+++ b/src/Controller/PaymentController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
+#[Route(format: 'json')]
 class PaymentController extends AbstractController
 {
     public function __construct(


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
Json Api endpoints should always return JSON, also for error responses in dev mode. While we're already transforming everything unknown to JSON for a successful response, everything else (like exceptions in dev mode) should be JSON too

### 2. What does this change do, exactly?
Add `format: 'json'` to all Json Api Controllers

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.