### PR TITLE
fix: general tab inheritance

### DIFF
--- a/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-general.vue
+++ b/assets/src/component/sw-braintree-app-settings/sw-braintree-app-settings-general.vue
@@ -4,28 +4,29 @@
     :title='$t("settings.general.title")'
     :is-loading='loading'
 >
-    <div class='sw-braintree-app-settings-general__threeDSecuredEnforced'>
+    <div class='content'>
         <mt-switch
-            class='sw-braintree-app-settings-general__threeDSecureEnforced__input'
+            class='sw-braintree-app-settings-general__threeDSecureEnforced'
             bordered
             :label='$t("settings.general.threeDSecureEnforced.label")'
-            :checked='activeConfig?.threeDSecureEnforced ?? undefined'
+            :checked='activeConfig.threeDSecureEnforced ?? rootConfig.threeDSecureEnforced ?? false'
+            :inherited-value='rootConfig.threeDSecureEnforced ?? false'
             :is-inherited='isFieldInherited("threeDSecureEnforced")'
             :is-inheritance-field='!!salesChannelId'
-            :help-text='$t("settings.general.threeDSecureToolTip")'
-            @change='activeConfig.threeDSecureEnforced = !activeConfig.threeDSecureEnforced'
-            @inheritance-remove='onRemove3DSInheritance()'
+            :help-text='$t("settings.general.threeDSecureEnforced.tooltip")'
+            @change='activeConfig.threeDSecureEnforced = $event'
+            @inheritance-remove='onRemoveInheritance("threeDSecureEnforced")'
             @inheritance-restore='onRestoreInheritance("threeDSecureEnforced")'
         />
-    </div>
-    <div class='sw-braintree-app-settings-general__shipsFromPostalCode'>
+
         <mt-text-field
-            class='sw-braintree-app-settings-general__shipsFromPostalCode__input'
+            class='sw-braintree-app-settings-general__shipsFromPostalCode'
             :label='$t("settings.general.shipsFromPostalCode.label")'
             :placeholder='$t("settings.general.shipsFromPostalCode.placeholder")'
+            :inherited-value='rootConfig.shipsFromPostalCode ?? ""'
             :is-inherited='isFieldInherited("shipsFromPostalCode")'
             :is-inheritance-field='!!salesChannelId'
-            :model-value='activeConfig.shipsFromPostalCode ?? ""'
+            :model-value='activeConfig.shipsFromPostalCode ?? rootConfig.shipsFromPostalCode ?? ""'
             @update:model-value='activeConfig.shipsFromPostalCode = $event'
             @inheritance-remove='onRemovePostalCodeInheritance()'
             @inheritance-restore='onRestoreInheritance("shipsFromPostalCode")'
@@ -77,44 +78,61 @@ export default defineComponent({
         },
 
         activeConfig(): ConfigEntity {
-            return this.config[this.stringifySalesChannelId] ?? DefaultConfigEntity(this.salesChannelId);
+            return this.config[this.stringifySalesChannelId] ?? {};
+        },
+
+        rootConfig(): ConfigEntity {
+            return this.config['null'] ?? {};
         },
     },
 
     watch: {
-        salesChannelId(){
-            void this.getConfig();
+        salesChannelId() {
+            if (!this.config[this.stringifySalesChannelId])
+                void this.getConfig(this.stringifySalesChannelId);
         },
     },
 
     created() {
-        void this.getConfig();
+        void this.getConfig('null');
         this.registerSaveHandler(this.updateConfig.bind(this));
     },
 
     methods: {
-        async getConfig(): Promise<void> {
-            if(this.config[this.stringifySalesChannelId]) return;
+        async getConfig(salesChannelId: string): Promise<void> {
+            this.loading = true;
 
-            return this.$api.get<ConfigEntity>('/entity/by-sales-channel/config/' + this.stringifySalesChannelId)
+            return this.$api.get<ConfigEntity>('/entity/by-sales-channel/config/' + salesChannelId)
                 .then((config) => {
-                    this.config[this.stringifySalesChannelId] = config;
-                    this.loading = false;
+                    this.config[String(config.salesChannelId)] = config;
+                    
+                    // add new config parameters
                     if (this.config['null']?.threeDSecureEnforced === null)
                         this.config['null'].threeDSecureEnforced = false;
 
+                    this.loading = false;
                 })
                 .catch((e) => this.$notify.error('fetch_settings', e));
         },
 
         async updateConfig(): Promise<void> {
-            return this.$api.patch<ConfigEntity>('/entity/config', Object.values(this.config))
-                .then(() => {
-                    this.config = {};
-                    void this.getConfig();
-                    this.$notify.success('save_settings');
-                })
-                .catch((e) => this.$notify.error('save_settings', e));
+            this.loading = true;
+            
+            try {
+                await this.$api.patch<ConfigEntity>('/entity/config', Object.values(this.config));
+                this.$notify.success('save_settings');
+
+                // reset, but preserve the active config to avoid flickering of toggles due to default values
+                this.config = {
+                    null: this.rootConfig,
+                    [this.stringifySalesChannelId]: this.activeConfig,
+                };
+
+                await Promise.all([this.getConfig('null'), this.getConfig(this.stringifySalesChannelId)]);
+            } catch (e) {
+                this.$notify.error('save_settings', e);
+                this.loading = false;
+            }
         },
 
         isFieldInherited(key: keyof ConfigEntity): boolean {
@@ -122,10 +140,6 @@ export default defineComponent({
                 return false;
 
             return this.activeConfig[key] === null;
-        },
-
-        onRemove3DSInheritance() {
-            this.activeConfig['threeDSecureEnforced'] = this.config['null']?.['threeDSecureEnforced'] ?? DefaultConfigEntity(this.salesChannelId)['threeDSecureEnforced'];
         },
 
         onRemovePostalCodeInheritance() {
@@ -147,11 +161,10 @@ export default defineComponent({
 
 <style lang='scss'>
 .sw-braintree-app-settings-general {
-    display: flex;
-    flex-direction: column;
-
-    &__shipsFromPostalCode {
-        margin-top: var(--scale-size-24);
+    .content {
+        display: flex;
+        flex-direction: column;
+        gap: var(--scale-size-24);
     }
 }
 </style>

--- a/assets/src/i18n/en-GB.json
+++ b/assets/src/i18n/en-GB.json
@@ -55,9 +55,9 @@
     "general": {
       "title": "General",
       "threeDSecureEnforced": {
-        "label": "Only accept transactions with 3D Secure"
+        "label": "Only accept transactions with 3D Secure",
+        "tooltip": "Transaction will not be accepted, if 3D Secure is not available"
       },
-      "threeDSecureToolTip": "Transaction will not be accepted, if 3D Secure is not available",
       "shipsFromPostalCode": {
         "label": "Sender shipping address postal code",
         "placeholder": "e.g. 48268"

--- a/assets/src/views/sw-braintree-app-order-transaction-detail.vue
+++ b/assets/src/views/sw-braintree-app-order-transaction-detail.vue
@@ -245,7 +245,7 @@ export default defineComponent({
             if (this.loadingTransaction || this.loadingShop || !this.transaction || !this.shop)
                 return '';
 
-            return `https://${this.shop?.braintreeSandbox ? 'sandbox.' : ''}braintreegateway.com/merchants/${this.shop?.braintreeMerchantId}/transactions/${this.transaction?.id}`;
+            return `https://${this.shop?.braintreeSandbox ? 'sandbox' : 'www'}.braintreegateway.com/merchants/${this.shop?.braintreeMerchantId}/transactions/${this.transaction?.id}`;
         },
     },
 

--- a/src/Entity/ConfigEntity.php
+++ b/src/Entity/ConfigEntity.php
@@ -51,7 +51,7 @@ class ConfigEntity implements EntityInterface
 
     public function setShipsFromPostalCode(?string $shipsFromPostalCode): self
     {
-        $this->shipsFromPostalCode = $shipsFromPostalCode ?: null;
+        $this->shipsFromPostalCode = $shipsFromPostalCode;
 
         return $this;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
- Inheritance was not showing as excepted, values flashing, loading states weren't applied correctly.

### 2. What does this change do, exactly?
- Always load config for "All sales channel" 
- Apply inheritance value
- correctly set and release loading state

### 3. Describe each step to reproduce the issue or behaviour.
Use general tab and switch between sales channels

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.