### PR TITLE
fix: vite port fsockopen timeout

### DIFF
--- a/src/Framework/Service/HmrService.php
+++ b/src/Framework/Service/HmrService.php
@@ -24,7 +24,7 @@ class HmrService
             return false;
         }
 
-        $connection = @\fsockopen('localhost', $this->vitePort);
+        $connection = @\fsockopen('localhost', $this->vitePort, timeout: 1);
 
         if (!\is_resource($connection)) {
             return false;


### PR DESCRIPTION
Somehow Windows Hosts on mirrored network with WSL active do not deny unused ports. This leads to fsockopen trying to get an active vite server connection over and over again. If the watcher is not active, this leads to retries for at least a minute, before fsockopen fails.

This fix introduces a timeout of one second, after which fsockopen immedately terminates the connection. Not an elegant solution, but a necessary one to work with WSL dev environments.