### PR TITLE
fix: handle unenrolled 3DS merchants

### DIFF
--- a/Resources/app/storefront/src/checkout/swag-braintree.hosted-fields.js
+++ b/Resources/app/storefront/src/checkout/swag-braintree.hosted-fields.js
@@ -11,6 +11,8 @@ import ElementLoadingIndicatorUtil from 'src/utility/loading-indicator/element-l
 const BASE_URL = 'https://braintree.shopware.com/api';
 
 /**
+ * @typedef {{ token: string, threeDS: { enforced: boolean, enabled: boolean } }} BraintreeClientConfig
+ *
  * @typedef {module:braintree-web/client.Client} BraintreeClient
  *
  * @typedef {module:braintree-web/hosted-fields.HostedFields} BraintreeHostedFields
@@ -24,6 +26,9 @@ const BASE_URL = 'https://braintree.shopware.com/api';
  * @typedef {module:braintree-web/data-collector.deviceData} BraintreeDeviceData
  */
 export default class SwagBraintreeHostedFields extends Plugin {
+    /** @type {BraintreeClientConfig} */
+    config;
+
     static options = {
         confirmOrderFormSelector: '#confirmOrderForm',
         confirmOrderButtonSelector: '#confirmOrderForm button[type=submit]',
@@ -53,6 +58,8 @@ export default class SwagBraintreeHostedFields extends Plugin {
 
         this._client = new AppClient('SwagBraintreeApp');
 
+        this.config = await this.getClientConfig();
+
         const braintreeClient = await this.createClient();
         const braintreeHostedFields = await this.createHostedFields(braintreeClient);
         const braintree3DS = await this.create3DSecure(braintreeClient);
@@ -69,16 +76,23 @@ export default class SwagBraintreeHostedFields extends Plugin {
     }
 
     /**
+     * @returns Promise<BraintreeClientConfig>
+     */
+    async getClientConfig() {
+        const request = await this._client.post(`${BASE_URL}/client/config?shop-id=${this.options.appShopId}&currency-id=${this.options.currencyId}&sales-channel-id=${this.options.salesChannelId}`);
+
+        if (!request.ok) {
+            throw new Error(await request.text())
+        }
+
+        return await request.json();
+    }
+
+    /**
      * @returns {Promise<BraintreeClient>} Client token of the merchant
      */
     async createClient() {
-        const request = await this._client.post(`${BASE_URL}/client/token?shop-id=${this.options.appShopId}&currency-id=${this.options.currencyId}&sales-channel-id=${this.options.salesChannelId}`);
-
-        if (!request.ok) throw new Error(await request.text());
-
-        const authorization = (await request.json()).token;
-
-        return BraintreeClient.create({ authorization });
+        return BraintreeClient.create({ authorization: this.config.token });
     }
 
     /**
@@ -119,9 +133,13 @@ export default class SwagBraintreeHostedFields extends Plugin {
 
     /**
      * @param {BraintreeClient} client
-     * @returns Promise<BraintreeThreeDSecure>
+     * @returns Promise<BraintreeThreeDSecure|null>
      */
     create3DSecure(client) {
+        if (!this.config.threeDS.enabled) {
+            return Promise.resolve(null);
+        }
+
         return Braintree3DSecure.create({
             client,
             version: 2
@@ -133,25 +151,29 @@ export default class SwagBraintreeHostedFields extends Plugin {
      * @returns Promise<BraintreeDataCollector>
      */
     createDataCollector(client) {
-        return BraintreeDataCollector.create({ client });
+        return BraintreeDataCollector.create({ client, kount: true });
     }
 
     /**
      * @param {BraintreeHostedFields} braintreeHostedFields
-     * @param {BraintreeThreeDSecure} braintree3DS
+     * @param {BraintreeThreeDSecure|null} braintree3DS
      * @param {Promise<BraintreeDataCollector>} braintreeDataCollector
      * @param {SubmitEvent} event
      */
     async onSubmitOrderConfirm(braintreeHostedFields, braintree3DS, braintreeDataCollector, event) {
         event.preventDefault();
 
-        if (!this.checkSubmitValidity(braintreeHostedFields)) return;
+        if (!this.checkSubmitValidity(braintreeHostedFields)) {
+            return;
+        }
 
         PageLoadingIndicatorUtil.create();
 
         let payload = await this.tokenizeTransaction(braintreeHostedFields);
 
-        payload = await this.validateWith3DSecure(braintree3DS, payload);
+        if (braintree3DS) {
+            payload = await this.validateWith3DSecure(braintree3DS, payload);
+        }
 
         const braintreeDeviceData = await (await braintreeDataCollector).getDeviceData();
 
@@ -168,7 +190,9 @@ export default class SwagBraintreeHostedFields extends Plugin {
      * @returns {HTMLElement|undefined} First invalid element if exists
      */
     checkValidity(braintreeHostedFields, state) {
-        if (!state) state = braintreeHostedFields.getState();
+        if (!state) {
+            state = braintreeHostedFields.getState();
+        }
 
         let invalid = undefined;
         for (let field of ['cvv', 'number', 'expirationDate', 'cardholderName', 'postalCode']) {
@@ -196,7 +220,9 @@ export default class SwagBraintreeHostedFields extends Plugin {
      */
     checkSubmitValidity(braintreeHostedFields) {
         const invalidField = this.checkValidity(braintreeHostedFields);
-        if (!invalidField) return true;
+        if (!invalidField) {
+            return true;
+        }
 
         invalidField.focus();
         invalidField.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -279,7 +305,9 @@ export default class SwagBraintreeHostedFields extends Plugin {
      * @private
      */
     resetOnSubmitError(error) {
-        if (!!error) console.error(error);
+        if (!!error) {
+            console.error(error);
+        }
 
         this.resetOrderConfirmButton();
         PageLoadingIndicatorUtil.remove();

--- a/devenv.lock
+++ b/devenv.lock
@@ -31,31 +31,10 @@
         "type": "github"
       }
     },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1750779888,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "git-hooks",
+          "pre-commit-hooks",
           "nixpkgs"
         ]
       },
@@ -87,14 +66,32 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754416808,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/src/Braintree/Payment/BraintreePaymentService.php
+++ b/src/Braintree/Payment/BraintreePaymentService.php
@@ -42,7 +42,12 @@ class BraintreePaymentService
         }
 
         $nonce = $this->extractNonce($payment);
-        $this->validateThreeDSecure($nonce, $this->salesChannelConfigService->isThreeDSecureEnforced($salesChannelId, $payment->shop));
+
+        $merchant = $this->gateway->merchantAccount()->find($merchantId);
+
+        if ($merchant->threeDSecure['v2']['enabled'] ?? false) {
+            $this->validateThreeDSecure($nonce, $this->salesChannelConfigService->isThreeDSecureEnforced($salesChannelId, $payment->shop));
+        }
 
         $billing = $this->orderInformationService->extractBillingAddress($payment);
         $shipping = $this->orderInformationService->extractShippingAddress($payment);

--- a/src/Controller/StorefrontController.php
+++ b/src/Controller/StorefrontController.php
@@ -24,6 +24,38 @@ class StorefrontController extends AbstractController
     }
 
     #[Route(
+        path: '/client/config',
+        name: 'braintree.client.config',
+        methods: [Request::METHOD_POST],
+    )]
+    public function getClientConfig(
+        StorefrontAction $storefrontAction,
+        #[MapQueryParameter(name: 'currency-id')]
+        ?string $currencyId = null,
+        #[MapQueryParameter(name: 'sales-channel-id')]
+        ?string $salesChannelId = null,
+    ): Response {
+        $currencyId ??= $storefrontAction->claims->getCurrencyId();
+        $salesChannelId ??= $storefrontAction->claims->getSalesChannelId();
+
+        $merchantAccountId = $this->salesChannelConfigService->getMerchantId($salesChannelId, $currencyId, $storefrontAction->shop);
+        $merchantAccount = $this->gateway->merchantAccount()->find($merchantAccountId);
+
+        $token = $this->gateway->clientToken()->generate(['merchantAccountId' => $merchantAccountId]);
+
+        $threeDSecureEnforced = $this->salesChannelConfigService->isThreeDSecureEnforced($salesChannelId, $storefrontAction->shop);
+
+        return new JsonResponse([
+            'threeDS' => [
+                'enforced' => $threeDSecureEnforced,
+                'enabled' => $merchantAccount->threeDSecure['v2']['enabled'] ?? false,
+            ],
+            'token' => $token,
+        ]);
+    }
+
+    #[\Deprecated(message: 'Use braintree.client.config instead.', since: '4.0.0')]
+    #[Route(
         path: '/client/token',
         name: 'braintree.client.token',
         methods: [Request::METHOD_POST]
@@ -35,13 +67,6 @@ class StorefrontController extends AbstractController
         #[MapQueryParameter(name: 'sales-channel-id')]
         ?string $salesChannelId = null,
     ): Response {
-        $currencyId ??= $storefrontAction->claims->getCurrencyId();
-        $salesChannelId ??= $storefrontAction->claims->getSalesChannelId();
-
-        $merchantAccount = $this->salesChannelConfigService->getMerchantId($salesChannelId, $currencyId, $storefrontAction->shop);
-
-        $token = $this->gateway->clientToken()->generate(['merchantAccountId' => $merchantAccount]);
-
-        return new JsonResponse(['token' => $token]);
+        return $this->redirectToRoute('braintree.client.config', ['currency-id' => $currencyId, 'sales-channel-id' => $salesChannelId]);
     }
 }

--- a/src/Controller/StorefrontController.php
+++ b/src/Controller/StorefrontController.php
@@ -67,6 +67,6 @@ class StorefrontController extends AbstractController
         #[MapQueryParameter(name: 'sales-channel-id')]
         ?string $salesChannelId = null,
     ): Response {
-        return $this->redirectToRoute('braintree.client.config', ['currency-id' => $currencyId, 'sales-channel-id' => $salesChannelId]);
+        return $this->getClientConfig($storefrontAction, $currencyId, $salesChannelId);
     }
 }

--- a/tests/unit/Braintree/Payment/BraintreePaymentServiceTest.php
+++ b/tests/unit/Braintree/Payment/BraintreePaymentServiceTest.php
@@ -4,6 +4,7 @@ namespace Swag\Braintree\Tests\Unit\Braintree\Payment;
 
 use Braintree\Exception\NotFound;
 use Braintree\Gateway;
+use Braintree\MerchantAccountGateway;
 use Braintree\PaymentMethodNonce;
 use Braintree\PaymentMethodNonceGateway;
 use Braintree\Result;
@@ -41,6 +42,8 @@ class BraintreePaymentServiceTest extends TestCase
 
     private MockObject&TransactionGateway $transactionGateway;
 
+    private MockObject&MerchantAccountGateway $merchantAccountGateway;
+
     private MockObject&PaymentMethodNonceGateway $paymentMethodNonceGateway;
 
     private MockObject&TransactionRepository $transactionRepository;
@@ -51,10 +54,12 @@ class BraintreePaymentServiceTest extends TestCase
     {
         $this->paymentMethodNonceGateway = $this->createMock(PaymentMethodNonceGateway::class);
         $this->transactionGateway = $this->createMock(TransactionGateway::class);
+        $this->merchantAccountGateway = $this->createMock(MerchantAccountGateway::class);
 
         $this->gateway = $this->createMock(Gateway::class);
         $this->gateway->method('paymentMethodNonce')->willReturn($this->paymentMethodNonceGateway);
         $this->gateway->method('transaction')->willReturn($this->transactionGateway);
+        $this->gateway->method('merchantAccount')->willReturn($this->merchantAccountGateway);
 
         $salesChannelConfigService = $this->createMock(SalesChannelConfigService::class);
         $salesChannelConfigService->method('getMerchantId')->willReturn('this-is-merchant-id');
@@ -119,6 +124,18 @@ class BraintreePaymentServiceTest extends TestCase
             }))
             ->willReturn($resultSuccess);
 
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) [
+                'threeDSecure' => [
+                    'v2' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ]);
+
         $paymentPayAction = $this->createPaymentPayAction($this->shop, [
             BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce',
             BraintreePaymentService::BRAINTREE_DEVICE_DATA => 'this-is-device-data',
@@ -181,6 +198,18 @@ class BraintreePaymentServiceTest extends TestCase
             ->method('sale')
             ->willReturn($resultError);
 
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) [
+                'threeDSecure' => [
+                    'v2' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ]);
+
         $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);
 
         static::expectException(BraintreePaymentException::class);
@@ -212,6 +241,18 @@ class BraintreePaymentServiceTest extends TestCase
             ->method('sale')
             ->willReturn($resultSuccess);
 
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) [
+                'threeDSecure' => [
+                    'v2' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ]);
+
         $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);
 
         static::expectException(BraintreePaymentException::class);
@@ -240,6 +281,18 @@ class BraintreePaymentServiceTest extends TestCase
             ->expects(static::never())
             ->method('sale');
 
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) [
+                'threeDSecure' => [
+                    'v2' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ]);
+
         $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);
 
         static::expectException(BraintreePaymentException::class);
@@ -266,6 +319,18 @@ class BraintreePaymentServiceTest extends TestCase
             ->expects(static::never())
             ->method('sale');
 
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) [
+                'threeDSecure' => [
+                    'v2' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ]);
+
         $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);
 
         static::expectException(BraintreePaymentException::class);
@@ -285,6 +350,18 @@ class BraintreePaymentServiceTest extends TestCase
         $this->transactionGateway
             ->expects(static::never())
             ->method('sale');
+
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) [
+                'threeDSecure' => [
+                    'v2' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ]);
 
         $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);
 

--- a/tests/unit/Braintree/Payment/BraintreePaymentServiceTest.php
+++ b/tests/unit/Braintree/Payment/BraintreePaymentServiceTest.php
@@ -400,6 +400,98 @@ class BraintreePaymentServiceTest extends TestCase
         $this->paymentService->handleTransaction($paymentPayAction);
     }
 
+    public function testHandleTransactionWithThreeDSecuredDisabled(): void
+    {
+        $salesChannelConfigService = $this->createMock(SalesChannelConfigService::class);
+        $salesChannelConfigService
+            ->method('getMerchantId')
+            ->willReturn('this-is-merchant-id');
+
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) [
+                'threeDSecure' => [
+                    'v2' => [
+                        'enabled' => false,
+                    ],
+                ],
+            ]);
+
+        $this->paymentService = new BraintreePaymentService(
+            $this->gateway,
+            $this->orderInformationService,
+            $salesChannelConfigService,
+            $this->transactionRepository,
+            $this->entityManager,
+        );
+
+        $this->paymentMethodNonceGateway
+            ->expects(static::never())
+            ->method('find');
+
+        $this->transactionGateway
+            ->expects(static::once())
+            ->method('sale')
+            ->willReturn(
+                new Result\Successful([
+                    'transaction' => Transaction::factory([
+                        'id' => 'this-is-transaction-id',
+                        'currencyIsoCode' => 'EUR',
+                        'amount' => 200,
+                    ]),
+                ], ['transaction'])
+            );
+
+        $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);
+
+        $this->paymentService->handleTransaction($paymentPayAction);
+    }
+
+    public function testHandleTransactionThreeDSecureDefault(): void
+    {
+        $salesChannelConfigService = $this->createMock(SalesChannelConfigService::class);
+        $salesChannelConfigService
+            ->method('getMerchantId')
+            ->willReturn('this-is-merchant-id');
+
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) []);
+
+        $this->paymentService = new BraintreePaymentService(
+            $this->gateway,
+            $this->orderInformationService,
+            $salesChannelConfigService,
+            $this->transactionRepository,
+            $this->entityManager,
+        );
+
+        $this->paymentMethodNonceGateway
+            ->expects(static::never())
+            ->method('find');
+
+        $this->transactionGateway
+            ->expects(static::once())
+            ->method('sale')
+            ->willReturn(
+                new Result\Successful([
+                    'transaction' => Transaction::factory([
+                        'id' => 'this-is-transaction-id',
+                        'currencyIsoCode' => 'EUR',
+                        'amount' => 200,
+                    ]),
+                ], ['transaction'])
+            );
+
+        $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);
+
+        $this->paymentService->handleTransaction($paymentPayAction);
+    }
+
     public function testExtractNonce(): void
     {
         $paymentPayAction = $this->createPaymentPayAction($this->shop, [BraintreePaymentService::BRAINTREE_NONCE => 'this-is-nonce']);

--- a/tests/unit/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Controller/StorefrontControllerTest.php
@@ -6,6 +6,7 @@ namespace Swag\Braintree\Tests\Unit\Controller;
 
 use Braintree\ClientTokenGateway;
 use Braintree\Gateway;
+use Braintree\MerchantAccountGateway;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -27,11 +28,20 @@ class StorefrontControllerTest extends TestCase
 
     private MockObject&SalesChannelConfigService $salesChannelConfigService;
 
+    private MockObject&MerchantAccountGateway $merchantAccountGateway;
+
     private StorefrontController $controller;
 
     protected function setUp(): void
     {
+        $this->merchantAccountGateway = $this->createMock(MerchantAccountGateway::class);
+
         $this->gateway = $this->createMock(Gateway::class);
+        $this->gateway
+            ->expects(static::any())
+            ->method('merchantAccount')
+            ->willReturn($this->merchantAccountGateway);
+
         $this->salesChannelConfigService = $this->createMock(SalesChannelConfigService::class);
         $this->controller = new StorefrontController(
             $this->gateway,
@@ -67,14 +77,26 @@ class StorefrontControllerTest extends TestCase
             ->with($expected['salesChannelId'], $expected['currencyId'], $shop)
             ->willReturn('this-is-merchant-id');
 
+        $this->salesChannelConfigService
+            ->expects(static::once())
+            ->method('isThreeDSecureEnforced')
+            ->with($expected['salesChannelId'], $shop)
+            ->willReturn(false);
+
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) ['threeDSecure' => ['v2' => ['enabled' => false]]]);
+
         $action = new StorefrontAction($shop, new StorefrontClaims($claims), new Collection());
 
-        $response = $this->controller->getClientToken($action, ...$queryParams);
+        $response = $this->controller->getClientConfig($action, ...$queryParams);
 
         $json = \json_decode($response->getContent(), true);
 
         static::assertNotNull($json);
-        static::assertSame(['token' => 'this-is-client-token'], $json);
+        static::assertSame(['threeDS' => ['enforced' => false, 'enabled' => false], 'token' => 'this-is-client-token'], $json);
     }
 
     public static function providerGetClientToken(): \Generator

--- a/tests/unit/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Controller/StorefrontControllerTest.php
@@ -54,8 +54,8 @@ class StorefrontControllerTest extends TestCase
      * @param StorefrontClaimsArray $claims
      * @param StorefrontClaimsArray $expected
      */
-    #[DataProvider('providerGetClientToken')]
-    public function testGetClientToken(array $queryParams, array $claims, array $expected): void
+    #[DataProvider('providerGetClientConfig')]
+    public function testGetClientConfig(array $queryParams, array $claims, array $expected): void
     {
         $clientToken = $this->createMock(ClientTokenGateway::class);
         $clientToken
@@ -99,7 +99,7 @@ class StorefrontControllerTest extends TestCase
         static::assertSame(['threeDS' => ['enforced' => false, 'enabled' => false], 'token' => 'this-is-client-token'], $json);
     }
 
-    public static function providerGetClientToken(): \Generator
+    public static function providerGetClientConfig(): \Generator
     {
         yield 'with query params' => [
             ['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'this-is-sales-channel-id'],
@@ -124,5 +124,165 @@ class StorefrontControllerTest extends TestCase
             ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'claim-sales-channel-id'],
             ['currencyId' => 'claim-currency-id', 'salesChannelId' => 'this-is-sales-channel-id'],
         ];
+    }
+
+    public function testThreeDSecureEnforced(): void
+    {
+        $clientToken = $this->createMock(ClientTokenGateway::class);
+        $clientToken
+            ->expects(static::once())
+            ->method('generate')
+            ->with(['merchantAccountId' => 'this-is-merchant-id'])
+            ->willReturn('this-is-client-token');
+
+        $this->gateway
+            ->expects(static::once())
+            ->method('clientToken')
+            ->willReturn($clientToken);
+
+        $shop = new ShopEntity('', '', '');
+
+        $this->salesChannelConfigService
+            ->expects(static::once())
+            ->method('getMerchantId')
+            ->with('this-is-sales-channel-id', 'this-is-currency-id', $shop)
+            ->willReturn('this-is-merchant-id');
+
+        $this->salesChannelConfigService
+            ->expects(static::once())
+            ->method('isThreeDSecureEnforced')
+            ->with('this-is-sales-channel-id', $shop)
+            ->willReturn(true);
+
+        $action = new StorefrontAction($shop, new StorefrontClaims(['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'this-is-sales-channel-id']), new Collection());
+        $response = $this->controller->getClientConfig($action, 'this-is-currency-id', 'this-is-sales-channel-id');
+
+        $json = \json_decode($response->getContent(), true);
+
+        static::assertNotNull($json);
+        static::assertArrayHasKey('threeDS', $json);
+        static::assertArrayHasKey('enforced', $json['threeDS']);
+        static::assertTrue($json['threeDS']['enforced']);
+    }
+
+    public function testThreeDSecureEnabled(): void
+    {
+        $clientToken = $this->createMock(ClientTokenGateway::class);
+        $clientToken
+            ->expects(static::once())
+            ->method('generate')
+            ->with(['merchantAccountId' => 'this-is-merchant-id'])
+            ->willReturn('this-is-client-token');
+
+        $this->gateway
+            ->expects(static::once())
+            ->method('clientToken')
+            ->willReturn($clientToken);
+
+        $shop = new ShopEntity('', '', '');
+
+        $this->salesChannelConfigService
+            ->expects(static::once())
+            ->method('getMerchantId')
+            ->with('this-is-sales-channel-id', 'this-is-currency-id', $shop)
+            ->willReturn('this-is-merchant-id');
+
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) ['threeDSecure' => ['v2' => ['enabled' => true]]]);
+
+        $action = new StorefrontAction($shop, new StorefrontClaims(['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'this-is-sales-channel-id']), new Collection());
+        $response = $this->controller->getClientConfig($action, 'this-is-currency-id', 'this-is-sales-channel-id');
+
+        $json = \json_decode($response->getContent(), true);
+
+        static::assertNotNull($json);
+        static::assertArrayHasKey('threeDS', $json);
+        static::assertArrayHasKey('enabled', $json['threeDS']);
+        static::assertTrue($json['threeDS']['enabled']);
+    }
+
+    public function testThreeDSecureEnabledDefault(): void
+    {
+        $clientToken = $this->createMock(ClientTokenGateway::class);
+        $clientToken
+            ->expects(static::once())
+            ->method('generate')
+            ->with(['merchantAccountId' => 'this-is-merchant-id'])
+            ->willReturn('this-is-client-token');
+
+        $this->gateway
+            ->expects(static::once())
+            ->method('clientToken')
+            ->willReturn($clientToken);
+
+        $shop = new ShopEntity('', '', '');
+
+        $this->salesChannelConfigService
+            ->expects(static::once())
+            ->method('getMerchantId')
+            ->with('this-is-sales-channel-id', 'this-is-currency-id', $shop)
+            ->willReturn('this-is-merchant-id');
+
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) []);
+
+        $action = new StorefrontAction($shop, new StorefrontClaims(['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'this-is-sales-channel-id']), new Collection());
+        $response = $this->controller->getClientConfig($action, 'this-is-currency-id', 'this-is-sales-channel-id');
+
+        $json = \json_decode($response->getContent(), true);
+
+        static::assertNotNull($json);
+        static::assertArrayHasKey('threeDS', $json);
+        static::assertArrayHasKey('enabled', $json['threeDS']);
+        static::assertFalse($json['threeDS']['enabled']);
+    }
+
+    public function testDeprecatedGetClientToken(): void
+    {
+        $clientToken = $this->createMock(ClientTokenGateway::class);
+        $clientToken
+            ->expects(static::once())
+            ->method('generate')
+            ->with(['merchantAccountId' => 'this-is-merchant-id'])
+            ->willReturn('this-is-client-token');
+
+        $this->gateway
+            ->expects(static::once())
+            ->method('clientToken')
+            ->willReturn($clientToken);
+
+        $shop = new ShopEntity('', '', '');
+
+        $this->salesChannelConfigService
+            ->expects(static::once())
+            ->method('getMerchantId')
+            ->with('this-is-sales-channel-id', 'this-is-currency-id', $shop)
+            ->willReturn('this-is-merchant-id');
+
+        $this->merchantAccountGateway
+            ->expects(static::once())
+            ->method('find')
+            ->with('this-is-merchant-id')
+            ->willReturn((object) []);
+
+        $action = new StorefrontAction($shop, new StorefrontClaims(['currencyId' => 'this-is-currency-id', 'salesChannelId' => 'this-is-sales-channel-id']), new Collection());
+        $response = $this->controller->getClientToken($action, 'this-is-currency-id', 'this-is-sales-channel-id');
+
+        $json = \json_decode($response->getContent(), true);
+
+        static::assertNotNull($json);
+        static::assertArrayHasKey('token', $json);
+        static::assertSame('this-is-client-token', $json['token']);
+        static::assertArrayHasKey('threeDS', $json);
+        static::assertArrayHasKey('enabled', $json['threeDS']);
+        static::assertArrayHasKey('enforced', $json['threeDS']);
+        static::assertFalse($json['threeDS']['enforced']);
+        static::assertFalse($json['threeDS']['enabled']);
     }
 }


### PR DESCRIPTION
Handle merchants, which are not enrolled in 3DS. This was a complete oversight in initial development.

This skips 3DS validation completely, if merchants are not enrolled / disabled it in their accounts.