### PR TITLE
fix(dependabot): ignore symfony major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
           - '*'
     ignore:
       - dependency-name: 'symfony/*'
-        update-types: ["version-update:semver-minor"]
+        update-types: [version-update:semver-minor]
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -25,7 +25,7 @@ updates:
           - '*'
     ignore:
       - dependency-name: typescript
-        update-types: ["version-update:semver-minor"]
+        update-types: [version-update:semver-minor]
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,22 @@
 version: 2
 updates:
-  - package-ecosystem: "composer"
-    directory: "/"
+  - package-ecosystem: composer
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
     commit-message:
       prefix: 'fix(deps): '
     groups:
       all:
         patterns:
           - '*'
-  - package-ecosystem: "npm"
-    directory: "/"
+    ignore:
+      - dependency-name: 'symfony/*'
+        update-types: ["version-update:semver-minor"]
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
     commit-message:
       prefix: 'fix(deps): '
     groups:
@@ -23,10 +26,10 @@ updates:
     ignore:
       - dependency-name: typescript
         update-types: ["version-update:semver-minor"]
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
     commit-message:
       prefix: 'fix(deps): '
     groups:


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
- We're not symfony 8 ready
- Dependabot interval is too frequent
