### PR TITLE
fix: admin font family name

### DIFF
--- a/assets/css/shopware-reboot.scss
+++ b/assets/css/shopware-reboot.scss
@@ -1,5 +1,5 @@
 *, body {
-    font-family: Inter var,-apple-system,blinkmacsystemfont,San Francisco,Segoe UI,roboto,Helvetica Neue,sans-serif;
+    font-family: Inter,-apple-system,blinkmacsystemfont,San Francisco,Segoe UI,roboto,Helvetica Neue,sans-serif;
     background: none;
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware Braintree App! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://github.com/shopware/braintree-app/blob/trunk/CONTRIBUTING.md).
-->

### 1. Why is this change necessary?
At some point, the font name of inter changed from `Inter var` to `Inter`

### 2. What does this change do, exactly?
Change font-familys to be the same like the administration

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.