### PR TITLE
fix: zero amount items

### DIFF
--- a/src/Braintree/Payment/OrderInformationService.php
+++ b/src/Braintree/Payment/OrderInformationService.php
@@ -89,6 +89,10 @@ class OrderInformationService
                 continue;
             }
 
+            if ($lineItem->getPrice()->getTotalPrice() === 0.0) {
+                continue;
+            }
+
             $lineItems[] = [
                 'commodityCode' => $this->extractCommodityCode($lineItem),
                 'description' => $this->substr($lineItem->getDescription(), 127),

--- a/tests/unit/Braintree/Payment/OrderInformationServiceTest.php
+++ b/tests/unit/Braintree/Payment/OrderInformationServiceTest.php
@@ -286,7 +286,7 @@ class OrderInformationServiceTest extends TestCase
 
         $order = $this->createMock(Order::class);
         $order
-            ->expects($this->once())
+            ->expects(static::once())
             ->method('getLineItems')
             ->willReturn(new Collection([new LineItem($lineItemData)]));
 

--- a/tests/unit/Braintree/Payment/OrderInformationServiceTest.php
+++ b/tests/unit/Braintree/Payment/OrderInformationServiceTest.php
@@ -260,6 +260,49 @@ class OrderInformationServiceTest extends TestCase
         static::assertEquals(array_fill(0, 249, $expected), $lineItems);
     }
 
+    public function testExtractLineItemsWithZeroAmountItem(): void
+    {
+        $lineItemData = [
+            'label' => 'Free',
+            'good' => true,
+            'quantity' => 1,
+            'description' => 'foo',
+            'type' => 'product',
+            'referencedId' => 'product-id',
+            'payload' => [
+                'customFields' => [
+                    'commodityCode' => '123456789',
+                ],
+            ],
+            'price' => [
+                'totalPrice' => 0,
+                'unitPrice' => 0,
+                'calculatedTaxes' => [[
+                    'taxRate' => 19,
+                    'tax' => 0,
+                ]],
+            ],
+        ];
+
+        $order = $this->createMock(Order::class);
+        $order
+            ->expects($this->once())
+            ->method('getLineItems')
+            ->willReturn(new Collection([new LineItem($lineItemData)]));
+
+        $paymentPayAction = new PaymentPayAction(
+            $this->shop,
+            $this->createMock(ActionSource::class),
+            $order,
+            self::createOrderTransaction(),
+            null,
+        );
+
+        $lineItems = $this->orderInformationService->extractLineItems($paymentPayAction);
+
+        static::assertCount(0, $lineItems);
+    }
+
     public function testExtractDiscountAmount(): void
     {
         $discountAmount = $this->orderInformationService->extractDiscountAmount($this->paymentPayAction);


### PR DESCRIPTION
Fixes a bug, where braintree API cannot handle 0.0 total price items.

Fixes it by simply ignoring them during extraction in OrderInformationService.